### PR TITLE
Paul/proxy server removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Swell is a one-stop shop for sending and monitoring your API requests
 * **Jason Ou** - [jasonou1994](https://github.com/jasonou1994)
 * **Kyle Combs** - [texpatnyc](https://github.com/texpatnyc)
 * **Kwadwo Asamoah** - [addoasa](https://github.com/addoasa)
-* **Abby Chao** - [brandon6190](https://github.com/abbychao)
-* **Amanda Flink** - [jasonou1994](https://github.com/aflinky)
-* **Kajol Thapa** - [texpatnyc](https://github.com/kajolthapa)
+* **Abby Chao** - [abbychao](https://github.com/abbychao)
+* **Amanda Flink** - [aflinky](https://github.com/aflinky)
+* **Kajol Thapa** - [kajolthapa](https://github.com/kajolthapa)
 
 ## License
 

--- a/main.js
+++ b/main.js
@@ -268,26 +268,19 @@ app.on('activate', () => {
 
 ipcMain.on('asynchronous-message', (event, arg) => {
   const { method, headers, body, cookie} = arg.options;
-  console.log('arg.options', arg.options)
   fetch2(arg.reqResObj.url, { method, headers, body, cookie })
-    .then(response => 
-      
-      {
-        const [contentType] = response.headers._headers['content-type'];
-        const { headers } = response;
-        const contents = /json/.test(contentType) ? response.json() : response.text();
-        contents.then((body) => {
-          return res.send({
-            headers,
-            body,
-          });
-        });
-      }
-      
-      response.json())
-    .then(result => {
-      console.log('result', result);
-      event.sender.send('asynchronous-reply', {body: result})
+    .then((response) => {
+      console.log('response:', response)
+      console.log('response.headers:', response.headers)
+      console.log('response.headers.get', response.headers.get('content-type'))
+      const contentType = response.headers.get('content-type');
+      const { headers } = response;
+      const contents = /json/.test(contentType) ? response.json() : response.text();
+      contents
+    .then((body) => {
+        console.log('body', body)
+        event.sender.send('asynchronous-reply', {headers, body})
+      });
     })
     .catch(error => {
       console.log(error);

--- a/main.js
+++ b/main.js
@@ -271,9 +271,9 @@ app.on('activate', () => {
 ipcMain.on('asynchronous-message', (event, arg) => {
   console.log(arg.options)
   const { method, headers, body} = arg.options;
-  const cookies = arg.reqResObj.request.cookies;
-  console.log('COOKIES', cookies);
-  fetch2(arg.reqResObj.url, { method, headers, body, cookies })
+  // headers.cookie = arg.reqResObj.request.cookies;
+  // console.log('COOKIES', cookies);
+  fetch2(arg.reqResObj.url, { method, headers, body })
     .then((response) => {
       console.log('response.headers:', response.headers)
       console.log(response.ok);
@@ -283,7 +283,8 @@ ipcMain.on('asynchronous-message', (event, arg) => {
       const contents = /json/.test(response.headers.get('content-type')) ? response.json() : response.text();
       contents
       .then(body =>  {
-        console.log(body)
+        console.log(body);
+        // console.log(headers.cookies);
         event.sender.send('asynchronous-reply', {headers, body})
       })
       .catch(error => console.log('ERROR',error))

--- a/main.js
+++ b/main.js
@@ -15,6 +15,8 @@ const log = require('electron-log');
 // TouchBarButtons are our nav buttons(ex: Select All, Deselect All, Open Selected, Close Selected, Clear All)
 const { TouchBarButton, TouchBarSpacer } = TouchBar;
 
+const fetch2 = require('node-fetch');
+
 // configure logging
 autoUpdater.logger = log;
 autoUpdater.logger.transports.file.level = 'info';
@@ -263,3 +265,33 @@ app.on('activate', () => {
     createWindow();
   }
 });
+
+ipcMain.on('asynchronous-message', (event, arg) => {
+  const { method, headers, body, cookie} = arg.options;
+  console.log('arg.options', arg.options)
+  fetch2(arg.reqResObj.url, { method, headers, body, cookie })
+    .then(response => 
+      
+      {
+        const [contentType] = response.headers._headers['content-type'];
+        const { headers } = response;
+        const contents = /json/.test(contentType) ? response.json() : response.text();
+        contents.then((body) => {
+          return res.send({
+            headers,
+            body,
+          });
+        });
+      }
+      
+      response.json())
+    .then(result => {
+      console.log('result', result);
+      event.sender.send('asynchronous-reply', {body: result})
+    })
+    .catch(error => {
+      console.log(error);
+    })
+})
+
+

--- a/main.js
+++ b/main.js
@@ -266,6 +266,8 @@ app.on('activate', () => {
   }
 });
 
+
+// ipcMain listener that 
 ipcMain.on('asynchronous-message', (event, arg) => {
   console.log(arg.options)
   const { method, headers, body} = arg.options;
@@ -275,35 +277,18 @@ ipcMain.on('asynchronous-message', (event, arg) => {
     .then((response) => {
       console.log('response.headers:', response.headers)
       console.log(response.ok);
-      console.log(response.status);
-      console.log(response.statusText);
       const headers = response.headers.raw();
       headers.cookies = response.headers.get('set-cookie');
-      console.log('headers.cookies', headers.cookies);
-      console.log(response.headers.get('content-type'));
-      response.json()
+      console.log('RES COOKIES', headers.cookies);
+      const contents = /json/.test(response.headers.get('content-type')) ? response.json() : response.text();
+      contents
       .then(body =>  {
         console.log(body)
         event.sender.send('asynchronous-reply', {headers, body})
       })
+      .catch(error => console.log('ERROR',error))
     })
-      
-      // console.log('response.headers:', response.headers)
-      // console.log('response.headers.get', response.headers.get('content-type'))
-    //   const contentType = response.headers.get('content-type');
-    //   const { headers } = response;
-    //   const contents = /json/.test(contentType) ? response.json() : response.text();
-    //   contents
-    // .then((body) => {
-        // console.log('body', body)
-        // console.log('HEADERS', headers)
-        // console.log('HEADERS', Object.values(headers))
-        // event.sender.send('asynchronous-reply', response.headers.raw())
-      // });
-    // })
-    .catch(error => {
-      console.log(error);
-    })
+    .catch(error => console.log(error))
 })
 
 

--- a/main.js
+++ b/main.js
@@ -267,21 +267,40 @@ app.on('activate', () => {
 });
 
 ipcMain.on('asynchronous-message', (event, arg) => {
-  const { method, headers, body, cookie} = arg.options;
-  fetch2(arg.reqResObj.url, { method, headers, body, cookie })
+  console.log(arg.options)
+  const { method, headers, body} = arg.options;
+  const cookies = arg.reqResObj.request.cookies;
+  console.log('COOKIES', cookies);
+  fetch2(arg.reqResObj.url, { method, headers, body, cookies })
     .then((response) => {
-      console.log('response:', response)
       console.log('response.headers:', response.headers)
-      console.log('response.headers.get', response.headers.get('content-type'))
-      const contentType = response.headers.get('content-type');
-      const { headers } = response;
-      const contents = /json/.test(contentType) ? response.json() : response.text();
-      contents
-    .then((body) => {
-        console.log('body', body)
+      console.log(response.ok);
+      console.log(response.status);
+      console.log(response.statusText);
+      const headers = response.headers.raw();
+      headers.cookies = response.headers.get('set-cookie');
+      console.log('headers.cookies', headers.cookies);
+      console.log(response.headers.get('content-type'));
+      response.json()
+      .then(body =>  {
+        console.log(body)
         event.sender.send('asynchronous-reply', {headers, body})
-      });
+      })
     })
+      
+      // console.log('response.headers:', response.headers)
+      // console.log('response.headers.get', response.headers.get('content-type'))
+    //   const contentType = response.headers.get('content-type');
+    //   const { headers } = response;
+    //   const contents = /json/.test(contentType) ? response.json() : response.text();
+    //   contents
+    // .then((body) => {
+        // console.log('body', body)
+        // console.log('HEADERS', headers)
+        // console.log('HEADERS', Object.values(headers))
+        // event.sender.send('asynchronous-reply', response.headers.raw())
+      // });
+    // })
     .catch(error => {
       console.log(error);
     })

--- a/main.js
+++ b/main.js
@@ -131,7 +131,7 @@ function createWindow() {
     webPreferences: {
       "nodeIntegration": true,
       "sandbox": false,
-      webSecurity: false,
+      webSecurity: true,
     },
     icon: `${__dirname}/src/assets/icons/64x64.png`
   })
@@ -272,22 +272,15 @@ app.on('activate', () => {
 
 // ipcMain listener that 
 ipcMain.on('asynchronous-message', (event, arg) => {
-  console.log(arg.options)
   const { method, headers, body} = arg.options;
-  // headers.cookie = arg.reqResObj.request.cookies;
-  // console.log('COOKIES', cookies);
   fetch2(headers.url, { method, headers, body })
     .then((response) => {
       const headers = response.headers.raw();
-      // const receivedCookie = cookie.parse(response.headers.get('set-cookie'));
       const receivedCookie = headers['set-cookie'];
-      console.log('RES COOKIES', receivedCookie);
       headers.cookies = receivedCookie;
       const contents = /json/.test(response.headers.get('content-type')) ? response.json() : response.text();
       contents
       .then(body =>  {
-        console.log(body);
-        // console.log(headers.cookies);
         event.sender.send('asynchronous-reply', {headers, body})
       })
       .catch(error => console.log('ERROR',error))

--- a/main.js
+++ b/main.js
@@ -280,7 +280,7 @@ ipcMain.on('asynchronous-message', (event, arg) => {
     .then((response) => {
       const headers = response.headers.raw();
       // const receivedCookie = cookie.parse(response.headers.get('set-cookie'));
-      const receivedCookie = response.headers.get('set-cookie');
+      const receivedCookie = headers['set-cookie'];
       console.log('RES COOKIES', receivedCookie);
       headers.cookies = receivedCookie;
       const contents = /json/.test(response.headers.get('content-type')) ? response.json() : response.text();

--- a/main.js
+++ b/main.js
@@ -15,6 +15,9 @@ const log = require('electron-log');
 // TouchBarButtons are our nav buttons(ex: Select All, Deselect All, Open Selected, Close Selected, Clear All)
 const { TouchBarButton, TouchBarSpacer } = TouchBar;
 
+// basic http cookie parser
+const cookie = require('cookie');
+// node-fetch for the fetch request
 const fetch2 = require('node-fetch');
 
 // configure logging
@@ -273,13 +276,13 @@ ipcMain.on('asynchronous-message', (event, arg) => {
   const { method, headers, body} = arg.options;
   // headers.cookie = arg.reqResObj.request.cookies;
   // console.log('COOKIES', cookies);
-  fetch2(arg.reqResObj.url, { method, headers, body })
+  fetch2(headers.url, { method, headers, body })
     .then((response) => {
-      console.log('response.headers:', response.headers)
-      console.log(response.ok);
       const headers = response.headers.raw();
-      headers.cookies = response.headers.get('set-cookie');
-      console.log('RES COOKIES', headers.cookies);
+      // const receivedCookie = cookie.parse(response.headers.get('set-cookie'));
+      const receivedCookie = response.headers.get('set-cookie');
+      console.log('RES COOKIES', receivedCookie);
+      headers.cookies = receivedCookie;
       const contents = /json/.test(response.headers.get('content-type')) ? response.json() : response.text();
       contents
       .then(body =>  {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "apollo-link-ws": "^1.0.18",
     "chart.js": "^2.7.3",
     "classnames": "^2.2.6",
+    "cookie": "^0.4.0",
     "date-fns": "^1.29.0",
     "dexie": "^2.0.4",
     "electron-devtools-installer": "^2.2.4",

--- a/src/client/components/display/CookieTable.jsx
+++ b/src/client/components/display/CookieTable.jsx
@@ -11,6 +11,7 @@ class CookieTable extends Component {
     let cookieRowArray;
     if (Array.isArray(this.props.cookies)) {
       cookieRowArray = this.props.cookies.map((cookie, i) => {
+        console.log('COOKIE IN COOKIE TABLE',cookie)
         return <CookieTableRow className='cookieTableRow' cookie={cookie} key={i} ></CookieTableRow>
       })
     }

--- a/src/client/components/display/CookieTableCell.jsx
+++ b/src/client/components/display/CookieTableCell.jsx
@@ -8,10 +8,10 @@ class CookieTableCell extends Component {
     }
 
     render() {
-
+        console.log('bottom cookie table', this.props.detail)
         return (
           <div className='cookieTableCell'>
-            {this.props.detail}
+            {this.props.detail.toString()}
           </div>
         )
     }

--- a/src/client/components/display/CookieTableRow.jsx
+++ b/src/client/components/display/CookieTableRow.jsx
@@ -10,14 +10,17 @@ class CookieTableRow extends Component {
 
     render() {
         let tableCellArray = [];
-
+        console.log('this.props.cookie', this.props.cookie)
         for(const key in this.props.cookie) {
             tableCellArray.push(<CookieTableCell detail={this.props.cookie[key]} key={key}></CookieTableCell>)
         }
         if (!this.props.cookie.expirationDate) {
             tableCellArray.push(<CookieTableCell detail={''} key='expirationDate'></CookieTableCell>)
-        }
-        console.log('tableCellArray', tableCellArray);
+        } 
+        // else {
+        //     tableCellArray.push(<CookieTableCell detail={this.props.cookie.expirationDate} key='expirationDate'></CookieTableCell>)
+        // }
+        // console.log('tableCellArray', tableCellArray);
         return (
           <div className='cookieTableRow grid-9'>
               {tableCellArray}

--- a/src/client/components/display/CookieTableRow.jsx
+++ b/src/client/components/display/CookieTableRow.jsx
@@ -17,7 +17,7 @@ class CookieTableRow extends Component {
         if (!this.props.cookie.expirationDate) {
             tableCellArray.push(<CookieTableCell detail={''} key='expirationDate'></CookieTableCell>)
         }
-
+        console.log('tableCellArray', tableCellArray);
         return (
           <div className='cookieTableRow grid-9'>
               {tableCellArray}

--- a/src/client/controllers/httpController.js
+++ b/src/client/controllers/httpController.js
@@ -15,14 +15,14 @@ const httpController = {
     /*
      * TRY TO CONNECT AS HTTP2 FIRST IF HTTPS. If error, fallback to HTTP1.1 (WebAPI fetch)
      */
-    // if (reqResObj.protocol === 'https://' || reqResObj.protocol === 'http://') {
-    //   console.log('HTTPS, TRYING HTTP2');
+    if (reqResObj.protocol === 'https://' || reqResObj.protocol === 'http://') {
+      console.log('HTTPS, TRYING HTTP2');
       httpController.establishHTTP2Connection(reqResObj, connectionArray);
-    // } 
-    // else {
-    //   console.log('HTTP REQUEST, MOVING TO FETCH');
-      // httpController.establishHTTP1connection(reqResObj, connectionArray);
-    // }
+    } 
+    else {
+      console.log('HTTP REQUEST, MOVING TO FETCH');
+      httpController.establishHTTP1connection(reqResObj, connectionArray);
+    }
   },
 
   establishHTTP2Connection(reqResObj, connectionArray) {
@@ -339,7 +339,7 @@ const httpController = {
               // // the ResponseBody is the literal readable object containing our api content
               // // the raw unparsed response from localhost:7000
           const theResponseHeaders = response.headers;
-          console.log('theResponseHeaders',theResponseHeaders);
+          console.log('theResponseHeaders',typeof theResponseHeaders.cookies);
           const { body } = response;
           // Now that we have got to the full response headers for http from localhost:7000 we have bypassed cors and can use this data
           reqResObj.response.headers = theResponseHeaders;
@@ -347,8 +347,13 @@ const httpController = {
           const http1Sesh = session.defaultSession;
           let domain = reqResObj.host.split('//');
           domain.shift();
-          [domain] = domain.join('').split('.').splice(-2).join('.')
-            .split(':');
+          [domain] = domain.join('').split('.').splice(-2).join('.').split(':');
+
+          const receivedCookies = theResponseHeaders.cookies
+          
+          const mainCookies = { url: reqResObj.host  , name: 'received' , value: 'NEW COOKIE!'}
+          console.log('main', mainCookies)
+          http1Sesh.cookies.set(mainCookies, () => console.log('cookies added!'))
 
           http1Sesh.cookies.get({ domain }, (err, cookies) => {
             console.log('COOKIES RECEIVED', theResponseHeaders.cookies);
@@ -397,6 +402,7 @@ const httpController = {
 
     cookies.forEach((cookie) => {
       const cookieString = `${cookie.key}=${cookie.value}`;
+      document.cookie = cookieString;
       formattedHeaders.cookie = cookieString;
     });
 

--- a/src/client/controllers/httpController.js
+++ b/src/client/controllers/httpController.js
@@ -351,6 +351,8 @@ const httpController = {
             .split(':');
 
           http1Sesh.cookies.get({ domain }, (err, cookies) => {
+            console.log('COOKIES RECEIVED', theResponseHeaders.cookies);
+            console.log('SESSION.GET', cookies);
             if (cookies) {
               reqResObj.response.cookies = cookies;
               store.default.dispatch(actions.reqResUpdate(reqResObj));
@@ -395,7 +397,7 @@ const httpController = {
 
     cookies.forEach((cookie) => {
       const cookieString = `${cookie.key}=${cookie.value}`;
-      document.cookie = cookieString;
+      formattedHeaders.cookie = cookieString;
     });
 
     const outputObj = {

--- a/src/client/controllers/httpController.js
+++ b/src/client/controllers/httpController.js
@@ -255,7 +255,7 @@ const httpController = {
     //--------------------------------------------------------------------------------------------------------------
 
     // send information to the NODE side to do the fetch request
-    this.sendToMainForFetch({reqResObj, options})
+    this.sendToMainForFetch({options})
       .then((response) => {
         console.log('response from 1st Fetch', response);
         console.log('response from 1st Fetch - RES.HEADERS', response.headers);
@@ -339,7 +339,7 @@ const httpController = {
               // // the ResponseBody is the literal readable object containing our api content
               // // the raw unparsed response from localhost:7000
           const theResponseHeaders = response.headers;
-          console.log('theResponseHeaders',typeof theResponseHeaders.cookies);
+          console.log('theResponseHeaders', theResponseHeaders);
           const { body } = response;
           // Now that we have got to the full response headers for http from localhost:7000 we have bypassed cors and can use this data
           reqResObj.response.headers = theResponseHeaders;
@@ -349,9 +349,20 @@ const httpController = {
           domain.shift();
           [domain] = domain.join('').split('.').splice(-2).join('.').split(':');
 
-          const receivedCookies = theResponseHeaders.cookies
+          const receivedCookies = theResponseHeaders.cookies.split
+          console.log(theResponseHeaders['set-cookie'][0].split(';')[0].split('='));
+
+
+          // check if   
+          const responseCookieName = theResponseHeaders['set-cookie'][0].split(';')[0].split('=')[0];
+          const responseCookieValue = theResponseHeaders['set-cookie'][0].split(';')[0].split('=')[1];
           
-          const mainCookies = { url: reqResObj.host  , name: 'received' , value: 'NEW COOKIE!'}
+          const mainCookies = { 
+            url: reqResObj.host,
+            name: responseCookieName,
+            value: responseCookieValue,
+            // expriationDate: theResponseHeaders.cookies.Expires,
+          }
           console.log('main', mainCookies)
           http1Sesh.cookies.set(mainCookies, () => console.log('cookies added!'))
 
@@ -402,7 +413,9 @@ const httpController = {
 
     cookies.forEach((cookie) => {
       const cookieString = `${cookie.key}=${cookie.value}`;
+      // saving cookies in the chromium instance
       document.cookie = cookieString;
+      // attach to formattedHeaders so options object includes this
       formattedHeaders.cookie = cookieString;
     });
 

--- a/src/client/controllers/httpController.js
+++ b/src/client/controllers/httpController.js
@@ -261,13 +261,6 @@ const httpController = {
         // Parse response headers now to decide if SSE or not.
         const heads = response.headers;
 
-        // for (const entry of response.headers) {
-        //   console.log('entry', entry);
-        //   console.log('entry[0]',entry[0].toLowerCase());
-        //   console.log('entry[1]', entry[1]);
-        //   heads[entry[0].toLowerCase()] = entry[1];
-        // }
-
         reqResObj.response.headers = heads;
         
         // store extracted headers in heads object
@@ -305,32 +298,13 @@ const httpController = {
           
           reqResObj.timeSent = Date.now();
           store.default.dispatch(actions.reqResUpdate(reqResObj));
-          
-          // fetch2(reqResObj.url, options)// fetch to OUR local proxy server before fetching to url provided
-          
-          // function sendToMainForFetch(args) {
-          //   console.log('before 2nd fetch')
-          //   return new Promise (resolve => {
-          //     ipcRenderer.send('asynchronous-message', args)
-          //     ipcRenderer.on('asynchronous-reply', (event, result) => {
-          //       resolve(result);
-          //     })
-          //   })
-          // }
 
-        // console.log(sendToMainForFetch({reqResObj, options}))
-        //  sendToMainForFetch({reqResObj, options})
-            // .then(response => {
-            //   console.log('2nd fetch request', response);
-            //   response.json()}
-            //   )
-            // .then((result) => {
-              // console.log('result 2nd fetch:', result);
-              // // the readable version of our response is an object that looks like this:
-              // // {headers:{**response headers go here**}, body:{**api content here**}, rawResponse:{**object with data about response**} }
-              // // theResponseHeaders refers to our literal object of response headers
-              // // the ResponseBody is the literal readable object containing our api content
-              // // the raw unparsed response from localhost:7000
+              //! Old proxy comments
+              // the readable version of our response is an object that looks like this:
+              // {headers:{**response headers go here**}, body:{**api content here**}, rawResponse:{**object with data about response**} }
+              // theResponseHeaders refers to our literal object of response headers
+              // the ResponseBody is the literal readable object containing our api content
+              // the raw unparsed response from localhost:7000
           const theResponseHeaders = response.headers;
 
           console.log('COOKIE RECEIVED',theResponseHeaders.cookies)
@@ -346,9 +320,8 @@ const httpController = {
           domain.shift();
           [domain] = domain.join('').split('.').splice(-2).join('.').split(':');
           console.log('DOMAIN', domain);
-          // const receivedCookies = theResponseHeaders.cookies.split
-          // console.log(theResponseHeaders['set-cookie'][0].split(';')[0].split('='));
 
+          // if cookies exists, parse the cookie(s)
           if (theResponseHeaders.cookies) {
             const splitCookies = theResponseHeaders.cookies;
             console.log('SPLIT C',splitCookies)
@@ -374,7 +347,7 @@ const httpController = {
   
               for (let i = 1; i < cookieArray.length; i++) {
                 if (cookieArray[i][0].toLowerCase() === 'expires') cookieFormat.expriationDate = new Date(cookieArray[i][1]).getTime();
-                // this secure option is not working for some reason - disabled for now
+                //! this secure option is not working for some reason - disabled for now
                 // if (cookieArray[i][0].toLowerCase() === 'secure') cookieFormat.secure = true
                 if (cookieArray[i][0].toLowerCase() === 'httponly') cookieFormat.httpOnly = true;
               }
@@ -405,11 +378,6 @@ const httpController = {
             // Below the headers and response api content are handled by swell and will be displayed.
             this.handleSingleEvent(body, reqResObj, theResponseHeaders);
           });
-            // })
-            // .catch((err) => {
-            //   reqResObj.connection = 'error';
-            //   store.default.dispatch(actions.reqResUpdate(reqResObj));
-            // });
         }
       })
       .catch((err) => {


### PR DESCRIPTION
9/17 Progress / update:

- We tested that having ONE fetch and killing the proxy works
- Tested with an end point that had strict CORS rules; https://joke-api-strict-cors.appspot.com/jokes/random
- Moved the fetching process to the node side and http controller just runs a function that communicates to the node ipc-main emitter
- created a cookie parsing logic inside the http controller to handle multiple response cookies
- need to create conditionals to handle case for no cookies sent back
- once cleaned up we need to modularize the process
- Remaining to dos: find and render expiration dates for response cookies, http2 response cookies are lost