### PR TITLE
Add error handling on HTTP1 requests to check for SSE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6997,7 +6997,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7015,11 +7016,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7032,15 +7035,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7143,7 +7149,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7153,6 +7160,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7165,17 +7173,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7192,6 +7203,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7264,7 +7276,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7274,6 +7287,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7349,7 +7363,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7379,6 +7394,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7396,6 +7412,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7434,11 +7451,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/client/controllers/httpController.js
+++ b/src/client/controllers/httpController.js
@@ -196,7 +196,7 @@ const httpController = {
         this.handleSingleEvent(body, reqResObj, theResponseHeaders);
       }
     })
-    
+
     reqStream.setEncoding('utf8');
     let data = '';
     reqStream.on('data', (chunk) => {
@@ -246,8 +246,8 @@ const httpController = {
 
   sendToMainForFetch(args) {
     return new Promise(resolve => {
-      ipcRenderer.send('asynchronous-message', args)
-      ipcRenderer.on('asynchronous-reply', (event, result) => {
+      ipcRenderer.send('http1-fetch-message', args)
+      ipcRenderer.on('http1-fetch-reply', (event, result) => {
         resolve(result);
       })
     })
@@ -334,7 +334,7 @@ const httpController = {
           reqResObj.response.headers = theResponseHeaders;
 
           // if cookies exists, parse the cookie(s)
-          if (setCookie.parse(theResponseHeaders.cookies)) {    
+          if (setCookie.parse(theResponseHeaders.cookies)) {
             reqResObj.response.cookies = this.cookieFormatter(setCookie.parse(theResponseHeaders.cookies));
             store.default.dispatch(actions.reqResUpdate(reqResObj));
             this.handleSingleEvent(body, reqResObj, theResponseHeaders);
@@ -491,7 +491,7 @@ const httpController = {
     );
   },
 
-  cookieFormatter (cookieArray) {
+  cookieFormatter(cookieArray) {
     return cookieArray.map((eachCookie) => {
       const cookieFormat = {
         name: eachCookie.name,


### PR DESCRIPTION
Added error handling for SSE on HTTP1 requests.
Added unique / more descriptive IPC events for HTTP requests.

Co-authored-by: Billy Tran <billy.tran61@gmail.com>
Co-authored-by: Anthony Toreson <anthony.toreson@gmail.com>