### PR TITLE
Fixed Tab Switching in History for gRPC requests 

### DIFF
--- a/src/client/components/composer/NewRequest/FieldEntryForm.jsx
+++ b/src/client/components/composer/NewRequest/FieldEntryForm.jsx
@@ -10,7 +10,11 @@ class FieldEntryForm extends Component {
   }
 
   onChangeHandler(e, property, graphQL) {
+    console.log('graphQL from onchangehandler in field entry form', graphQL)
     let value = e.target.value;
+    // if (!e.target.value) value = 'GRPC'
+    console.log('value from event in field entry form', value)
+
     switch (property) {
       case 'url': {
         let url = value;
@@ -168,6 +172,8 @@ class FieldEntryForm extends Component {
   // }
 
   render() {
+    console.log('what is this field entry form', this.props.newRequestFields)
+
 
     return (
       <div>

--- a/src/client/components/composer/NewRequest/HeaderEntryForm.jsx
+++ b/src/client/components/composer/NewRequest/HeaderEntryForm.jsx
@@ -28,7 +28,7 @@ class HeaderEntryForm extends Component {
 
   checkContentTypeHeaderUpdate() {
     let contentType;
-    console.log(this.props.newRequestBody.bodyType)
+    // console.log(this.props.newRequestBody.bodyType)
 
     if (this.props.newRequestBody.bodyType === 'GRPC') {
       contentType = ''

--- a/src/client/components/display/History.jsx
+++ b/src/client/components/display/History.jsx
@@ -12,12 +12,17 @@ class History extends Component {
   }
 
   addHistoryToNewRequest() {
+    console.log('this is the content', this.props.content)
+
     const requestFieldObj = {
       method: this.props.content.request.method ? this.props.content.request.method : 'GET',
       protocol: this.props.content.protocol ? this.props.content.protocol : 'http://',
       url: this.props.content.url ? this.props.content.url : 'http://',
-      graphQL: this.props.content.graphQL ? this.props.content.graphQL : false
+      graphQL: this.props.content.graphQL ? this.props.content.graphQL : false,
+      gRPC: this.props.content.protocol === '' ? true : null
     }
+
+
 
     let headerDeeperCopy;
     if (this.props.content.request.headers) {

--- a/src/client/components/display/HistoryDate.jsx
+++ b/src/client/components/display/HistoryDate.jsx
@@ -13,6 +13,8 @@ class HistoryDate extends Component {
   }
 
   focusOnForm(event) {
+    console.log('history date this is the changed tab',document.querySelector('.composer_url_input'))
+    // console.log('this is the new request field', this.props.NewRequestFields)
     let composerUrlField = document.querySelector('.composer_url_input');
     composerUrlField.focus()
   }


### PR DESCRIPTION
The RequestFieldObj didn't properly populate with the GRPC property from content, and never switched to the GRPC tab when a GRPC request was clicked. This works now.