### PR TITLE
fixed post request styling and tab switching bugs 

### DIFF
--- a/src/client/components/composer/NewRequest/ComposerNewRequest.jsx
+++ b/src/client/components/composer/NewRequest/ComposerNewRequest.jsx
@@ -170,7 +170,6 @@ class ComposerNewRequest extends Component {
       }
       // grpc requests
       else if (this.props.newRequestFields.gRPC) {
-
         let URIWithoutProtocol = `${this.props.newRequestFields.url}`;
         const host = protocol + URIWithoutProtocol.split('/')[0];
         // populate the history if there is body content
@@ -205,10 +204,11 @@ class ComposerNewRequest extends Component {
         const grpcStream = document.getElementById('stream').innerText;
 
         // create reqres obj to be passed to controller for further actions/tasks
+
         reqRes = {
           id: uuid(),
           created_at: new Date(),
-          protocol: '',
+          protocol: 'https://',
           host,
           path,
           url: this.props.newRequestFields.url,
@@ -306,6 +306,29 @@ class ComposerNewRequest extends Component {
         JSONFormatted: true,
       });
 
+      if (this.props.newRequestFields.gRPC) {
+        this.props.setNewRequestBody({
+          ...this.newRequestBody,
+          bodyContent: '',
+          bodyVariables: '',
+          bodyType: 'GRPC',
+          rawType: '',
+          JSONFormatted: true,
+        });
+      }
+
+      if (this.props.newRequestFields.graphQL) {
+
+        this.props.setNewRequestBody({
+          ...this.newRequestBody,
+          bodyContent: '',
+          bodyVariables: '',
+          bodyType: 'GQL',
+          rawType: '',
+          JSONFormatted: true,
+        });
+      }
+
       this.props.setNewRequestFields({
         method: this.props.newRequestFields.method,
         protocol: '',
@@ -313,6 +336,18 @@ class ComposerNewRequest extends Component {
         graphQL: this.props.newRequestFields.graphQL,
         gRPC: this.props.newRequestFields.gRPC,
       });
+
+      if(this.props.newRequestFields.protocol === 'ws://') {
+      this.props.setNewRequestFields({
+        method: this.props.newRequestFields.method,
+        protocol: 'ws://',
+        url: 'ws://',
+        graphQL: this.props.newRequestFields.graphQL,
+        gRPC: this.props.newRequestFields.gRPC,
+      });
+    }
+
+      
       this.props.setNewRequestSSE(false);
     }
     else {

--- a/src/client/components/composer/NewRequest/FieldEntryForm.jsx
+++ b/src/client/components/composer/NewRequest/FieldEntryForm.jsx
@@ -172,8 +172,6 @@ class FieldEntryForm extends Component {
   // }
 
   render() {
-    console.log('what is this field entry form', this.props.newRequestFields)
-
 
     return (
       <div>

--- a/src/client/components/composer/NewRequest/HeaderEntryForm.jsx
+++ b/src/client/components/composer/NewRequest/HeaderEntryForm.jsx
@@ -24,6 +24,7 @@ class HeaderEntryForm extends Component {
       this.addHeader(headersDeepCopy);
     }
     this.checkContentTypeHeaderUpdate();
+
   }
 
   checkContentTypeHeaderUpdate() {

--- a/src/client/components/composer/protos/saveProto.proto
+++ b/src/client/components/composer/protos/saveProto.proto
@@ -16,14 +16,14 @@ message HelloRequest {
   string name = 1;
 }
 
-// The request message containing the user's name.
-message HelloHowOldRequest {
-  int32 age = 1;
-}
-
 // The response message containing the greetings
 message HelloReply {
   string message = 1;
+}
+
+// The request message containing the user's name.
+message HelloHowOldRequest {
+  int32 age = 1;
 }
 message HelloAge {
   int32 age = 1;

--- a/src/client/components/display/History.jsx
+++ b/src/client/components/display/History.jsx
@@ -12,14 +12,13 @@ class History extends Component {
   }
 
   addHistoryToNewRequest() {
-    console.log('this is the content', this.props.content)
 
     const requestFieldObj = {
       method: this.props.content.request.method ? this.props.content.request.method : 'GET',
       protocol: this.props.content.protocol ? this.props.content.protocol : 'http://',
       url: this.props.content.url ? this.props.content.url : 'http://',
       graphQL: this.props.content.graphQL ? this.props.content.graphQL : false,
-      gRPC: this.props.content.protocol === '' ? true : null
+      gRPC: this.props.content.gRPC ? this.props.content.gRPC : false
     }
 
 


### PR DESCRIPTION
After a request is sent, the styling for the add header button is changed to HTTP styling, and the tab often switches to the HTTP tab. The properties for these are now carried down from ComposerNewRequest.