### PR TITLE
headers for gRPC, websocket message styling

### DIFF
--- a/src/client/components/containers/ResponseContainer.jsx
+++ b/src/client/components/containers/ResponseContainer.jsx
@@ -37,6 +37,11 @@ class ResponseContainer extends Component {
           openTab: val,
         });
         break;
+      case 'Response Metadata':
+        this.setState({
+          openTab: val,
+        });
+        break;
       case 'Response Headers':
         this.setState({
           openTab: val,
@@ -47,7 +52,7 @@ class ResponseContainer extends Component {
           openTab: val,
         });
         break;
-     
+
       default:
     }
   }
@@ -69,6 +74,7 @@ class ResponseContainer extends Component {
           && <ResponseEventsDisplay response={this.props.content.response} />
         }
         {this.state.openTab === 'Response Headers' && <ResponseHeadersDisplay responseContent={this.props.content.response} />}
+        {this.state.openTab === 'Response Metadata' && <ResponseHeadersDisplay responseContent={this.props.content.response} />}
         {this.state.openTab === 'Response Cookies' && <ResponseCookiesDisplay responseContent={this.props.content.response} />}
       </div>
     );

--- a/src/client/components/display/ResponseTabs.jsx
+++ b/src/client/components/display/ResponseTabs.jsx
@@ -7,9 +7,14 @@ class ResponseTabs extends Component {
   }
 
   render() {
+    console.log('THETSHESTRKSDFKJHS', this.props.content)
     const events = 'Response Events';
     const cookies = 'Response Cookies';
     let headers = 'Response Headers';
+
+    if (this.props.content.gRPC === true ) {
+      headers = 'Response Metadata';
+    }
     return (
       <ul className="tab_list-response">
         <Tab onTabSelected={this.props.handleTabSelect} tabName={events} key="events" openTab={this.props.openResponseTab}/>
@@ -24,3 +29,5 @@ class ResponseTabs extends Component {
 }
 
 export default ResponseTabs;
+
+

--- a/src/client/components/display/WebSocketMessage.jsx
+++ b/src/client/components/display/WebSocketMessage.jsx
@@ -10,6 +10,7 @@ class WebSocketMessage extends Component {
   render() {
     const styles = {
       display: 'flex',
+      overflow: 'hidden',
       justifyContent: this.props.source === 'server' ? 'flex-start' : 'flex-end',
     };
 
@@ -22,7 +23,7 @@ class WebSocketMessage extends Component {
 
     return (
       <div style={styles} className={webSocketMessageClassNames}>
-        <div className={'websocket_message-data'}><div>{this.props.data}</div></div>
+        <div style={styles} className={'websocket_message-data'}><div>{this.props.data}</div></div>
         <div  className={'websocket_message-time'}>{`${hours}:${minutes}`}</div>
       </div>
     );

--- a/src/client/controllers/grpcController.js
+++ b/src/client/controllers/grpcController.js
@@ -185,7 +185,7 @@ grpcController.openGrpcConnection = (reqResObj, connectionArray) => {
           // request without overwrite
           reqResObj.connection = 'pending';
           reqResObj.connectionType = 'plain';
-          reqResObj.timeSent = Date.now();
+          reqResObj.timeReceived = Date.now();
           call.write(query);
           // add console log for completed write?
         }
@@ -239,7 +239,7 @@ grpcController.openGrpcConnection = (reqResObj, connectionArray) => {
           for (let i = 0; i < keys.length; i += 1) {
             let key = keys[i];
             reqResObj.response.headers[key] = metadata._internal_repr[key][0];
-            console.log('reqred headers are now', reqResObj.response.headers)
+            console.log('reqres headers are now: ', reqResObj.response.headers)
           }
           store.default.dispatch(actions.reqResUpdate(reqResObj))
         })
@@ -265,7 +265,7 @@ grpcController.openGrpcConnection = (reqResObj, connectionArray) => {
             for (let i = 0; i < keys.length; i += 1) {
               let key = keys[i];
               reqResObj.response.headers[key] = metadata._internal_repr[key][0];
-              console.log('reqred headers are now', reqResObj.response.headers)
+              console.log('reqres headers are now: ', reqResObj.response.headers)
             }
             store.default.dispatch(actions.reqResUpdate(reqResObj))
           });


### PR DESCRIPTION
The header for metadata in response tabs is now dynamic based on the current tab. websocket messages no longer have horizontal/vertical scroll bars.