### PR TITLE
Debug npm install errors for "postinstall"

### DIFF
--- a/grpc_mockData/server.js
+++ b/grpc_mockData/server.js
@@ -35,7 +35,7 @@ function sayHello(ctx) {
   metadata.set('indeed', 'it do')
   // Watcher creates a watch execution context for the watch
   // The execution context provides scripts and templates with access to the watch metadata
-  console.log("received metadata from client request", ctx.metadata)
+  console.log("received metadata from client request", ctx.meta)
   // console.dir(ctx.metadata, { depth: 3, colors: true });
   console.log(`got sayHello request name: ${ctx.req.name}`);
   

--- a/package.json
+++ b/package.json
@@ -143,7 +143,8 @@
     "verbose": true,
     "collectCoverage": true,
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "./__mocks__/fileMock.js"
+      "electron": "<rootDir>/__mocks__/electronMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|png)$": "<rootDir>/__mocks__/electronMock.js"
     }
   },
   "license": "MIT",
@@ -197,7 +198,8 @@
     "status-indicator": "^1.0.9",
     "subscriptions-transport-ws": "^0.9.16",
     "uuid": "^3.3.2",
-    "ws": "^6.1.2"
+    "ws": "^6.1.2",
+    "node-pre-gyp": "0.6.x"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/src/client/controllers/grpcController.js
+++ b/src/client/controllers/grpcController.js
@@ -97,6 +97,7 @@ grpcController.openGrpcConnection = (reqResObj, connectionArray) => {
       // create client requested metadata key and value pair for each type of streaming
       let meta = new grpc.Metadata()
       let metaArr = reqResObj.request.headers;
+      console.log("metaArr from grpcController line 100:", metaArr)
       for (let i = 0; i < metaArr.length; i+=1) {
         let currentHeader = metaArr[i];
         meta.add(currentHeader.key, currentHeader.value)


### PR DESCRIPTION
added node-pre-gyp to dependencies to correctly build "npm rebuild --runtime=electron --target=7.0.1" on mac.