### PR TITLE
Refactor HTTP2 portion of HTTP Controller to disallow Node Integration

### DIFF
--- a/httpMainController.js
+++ b/httpMainController.js
@@ -1,0 +1,58 @@
+const nodeFetch = require('node-fetch'); 
+const http2 = require("http2");
+const setCookie = require("set-cookie-parser");
+
+const httpMainController = {}; 
+
+// array of open http2 connections
+httpMainController.openHTTP2Connections = []; 
+
+httpMainController.openHTTPconnection = (reqResObj, connectionArray) => {
+  // http2 is currentonly supported over https
+  reqResObj.protocol === "https://"
+    ? httpController.establishHTTP2Connection(reqResObj, connectionArray)
+    : httpController.establishHTTP1connection(reqResObj, connectionArray);
+};
+
+httpMainController.establishHTTP2Connection = (reqResObj, connectionArray) => {
+    /*
+      Attempt to find an existing HTTP2 connection in openHTTP2Connections Array.
+      If exists, use connection to initiate request
+      If not, create connection, push to array, and then initiate request
+    */
+
+    // find connection with same host as passed in reqResObj 
+   const foundHTTP2Connection = httpMainController.openHTTP2Connections.find(
+    (conn) => conn.host === reqResObj.host
+  );
+
+  // EXISTING HTTP2 CONNECTION IS FOUND -----
+
+  if (foundHTTP2Connection) {
+    const { client } = foundHTTP2Connection;
+
+    // periodically check if the client is open or destroyed, and attach if conditions are met
+    const interval = setInterval(() => {
+      if (foundHTTP2Connection.status === "connected") {
+        this.attachRequestToHTTP2Client(client, reqResObj, connectionArray);
+        clearInterval(interval);
+      }
+      // if failed, could because of protocol error. try HTTP1
+      else if (foundHTTP2Connection.status === "failed" || client.destroyed) {
+        httpController.establishHTTP1connection(reqResObj, connectionArray);
+        clearInterval(interval);
+      }
+    }, 50);
+
+  // --------------------------------------------------
+      // if hasnt changed in 10 seconds, mark as error
+      // --------------------------------------------------
+      setTimeout(() => {
+        clearInterval(interval);
+        if (foundHTTP2Connection.status === "initialized") {
+          reqResObj.connection = "error";
+          store.default.dispatch(actions.reqResUpdate(reqResObj));
+        }
+      }, 10000);
+    }; 
+}

--- a/httpMainController.js
+++ b/httpMainController.js
@@ -1,58 +1,524 @@
-const nodeFetch = require('node-fetch'); 
+const { ipcMain } = require('electron'); 
+
+const fetch2 = require("node-fetch");
+//const { session } = require("electron").remote;
 const http2 = require("http2");
+
+// parsing through cookies
 const setCookie = require("set-cookie-parser");
 
-const httpMainController = {}; 
+//Included Functions
 
-// array of open http2 connections
-httpMainController.openHTTP2Connections = []; 
+// openHTTPconnection(reqResObj, connectionArray)
+// establishHTTP2Connection(reqResObj, connectionArray)
+// attachRequestToHTTP2Client(client, reqResObj, connectionArray)
+// sendToMainForFetch(args)
+// establishHTTP1connection(reqResObj, connectionArray)
+// parseFetchOptionsFromReqRes(reqResObject)
+// handleSingleEvent(response, originalObj, headers)
+// handleSSE(response, originalObj, headers)
+// parseSSEFields(rawString)
+// cookieFormatter(setCookie(response.cookies))
 
-httpMainController.openHTTPconnection = (reqResObj, connectionArray) => {
-  // http2 is currentonly supported over https
-  reqResObj.protocol === "https://"
-    ? httpController.establishHTTP2Connection(reqResObj, connectionArray)
-    : httpController.establishHTTP1connection(reqResObj, connectionArray);
-};
+const httpController = {
+  openHTTP2Connections: [],
 
-httpMainController.establishHTTP2Connection = (reqResObj, connectionArray) => {
+  // ----------------------------------------------------------------------------
+
+  openHTTPconnection(event, reqResObj, connectionArray) {
+    // HTTP2 currently only on HTTPS
+    reqResObj.protocol === "https://"
+      ? httpController.establishHTTP2Connection(event, reqResObj, connectionArray)
+      : httpController.establishHTTP1connection(event, reqResObj, connectionArray);
+  },
+
+  // ----------------------------------------------------------------------------
+
+  establishHTTP2Connection(event, reqResObj, connectionArray) {
     /*
       Attempt to find an existing HTTP2 connection in openHTTP2Connections Array.
       If exists, use connection to initiate request
       If not, create connection, push to array, and then initiate request
     */
+   
+    const foundHTTP2Connection = httpController.openHTTP2Connections.find(
+      (conn) => conn.host === reqResObj.host
+    );
 
-    // find connection with same host as passed in reqResObj 
-   const foundHTTP2Connection = httpMainController.openHTTP2Connections.find(
-    (conn) => conn.host === reqResObj.host
-  );
+    // EXISTING HTTP2 CONNECTION IS FOUND -----
 
-  // EXISTING HTTP2 CONNECTION IS FOUND -----
+    if (foundHTTP2Connection) {
+      const { client } = foundHTTP2Connection;
 
-  if (foundHTTP2Connection) {
-    const { client } = foundHTTP2Connection;
-
-    // periodically check if the client is open or destroyed, and attach if conditions are met
-    const interval = setInterval(() => {
-      if (foundHTTP2Connection.status === "connected") {
-        this.attachRequestToHTTP2Client(client, reqResObj, connectionArray);
-        clearInterval(interval);
-      }
-      // if failed, could because of protocol error. try HTTP1
-      else if (foundHTTP2Connection.status === "failed" || client.destroyed) {
-        httpController.establishHTTP1connection(reqResObj, connectionArray);
-        clearInterval(interval);
-      }
-    }, 50);
-
-  // --------------------------------------------------
+      // periodically check if the client is open or destroyed, and attach if conditions are met
+      const interval = setInterval(() => {
+        if (foundHTTP2Connection.status === "connected") {
+          this.attachRequestToHTTP2Client(client, event, reqResObj, connectionArray);
+          clearInterval(interval);
+        }
+        // if failed, could because of protocol error. try HTTP1
+        else if (foundHTTP2Connection.status === "failed" || client.destroyed) {
+          httpController.establishHTTP1connection(event, reqResObj, connectionArray);
+          clearInterval(interval);
+        }
+      }, 50);
+      // --------------------------------------------------
       // if hasnt changed in 10 seconds, mark as error
       // --------------------------------------------------
       setTimeout(() => {
         clearInterval(interval);
         if (foundHTTP2Connection.status === "initialized") {
           reqResObj.connection = "error";
-          store.default.dispatch(actions.reqResUpdate(reqResObj));
+          // SEND BACK REQ RES OBJECT TO RENDERER SO IT CAN UPDATE REDUX STORE
+          event.sender.send('reqResUpdate', reqResObj);
         }
       }, 10000);
-    }; 
-}
+    }
+    // --------------------------------------------------
+    // NO EXISTING HTTP2 CONNECTION - make it before attaching request
+    // --------------------------------------------------
+    else {
+      // console.log('New HTTP2 Conn:', reqResObj.host);
+
+      const id = Math.random() * 100000;
+      const client = http2.connect(reqResObj.host);
+
+      // push HTTP2 connection to array
+      const http2Connection = {
+        client,
+        id,
+        host: reqResObj.host,
+        status: "initialized",
+      };
+      httpController.openHTTP2Connections.push(http2Connection);
+
+      client.on("error", (err) => {
+        console.log("HTTP2 FAILED...trying HTTP1\n", err);
+        http2Connection.status = "failed";
+        client.destroy();
+
+        // if it exists in the openHTTP2Connections array, remove it
+        httpController.openHTTP2Connections = httpController.openHTTP2Connections.filter(
+          (conn) => conn.id !== id
+        );
+
+        // need to filter connectionArray for existing connObj as a nonfunctioning
+        // one may have been pushed in establishHTTP2connection...
+        // can't actually use filter though due to object renaming
+        connectionArray.forEach((obj, i) => {
+          if (obj.id === reqResObj.id) {
+            connectionArray.splice(i, 1);
+          }
+        });
+
+        // try again with fetch (HTTP1);
+        httpController.establishHTTP1connection(event, reqResObj, connectionArray);
+      });
+
+      client.on("connect", () => {
+        http2Connection.status = "connected";
+
+        // attach request, again passing in event so we can send response to renderer with event.sender.send()
+        this.attachRequestToHTTP2Client(client, event, reqResObj, connectionArray);
+      });
+    }
+  },
+
+  // ----------------------------------------------------------------------------
+
+  attachRequestToHTTP2Client(client, event, reqResObj, connectionArray) {
+    // start off by clearing existing response data
+    reqResObj.response.headers = {};
+    reqResObj.response.events = [];
+    reqResObj.connection = "pending";
+    reqResObj.timeSent = Date.now();
+    // send back reqResObj to renderer so it can update the redux store
+    event.sender.send('reqResUpdate', reqResObj);
+  
+    // format headers in chosen reqResObj so we can add them to our request
+    const formattedHeaders = {};
+    reqResObj.request.headers.forEach((head) => {
+      formattedHeaders[head.key] = head.value;
+    });
+    formattedHeaders[":path"] = reqResObj.path;
+
+    // initiate request
+    const reqStream = client.request(formattedHeaders, {
+      // do not immediately close the *writable* side of the http2 stream (i.e. what the request sends over), in case we are using a request method that sends a payload body
+      endStream: false,
+    });
+
+    // we can now close the writable side of our stream, either sending our request body or not, depending on our method
+    if (
+      reqResObj.request.method !== "GET" &&
+      reqResObj.request.method !== "HEAD"
+    ) {
+      reqStream.end(reqResObj.request.body);
+    } else {
+      console.log("ending request");
+      reqStream.end();
+    }
+
+    // create an object that represents our open connection.
+    const openConnectionObj = {
+      stream: reqStream,
+      protocol: "HTTP2",
+      id: reqResObj.id,
+    };
+
+    // this is the connection array that was passed into these controller functions from reqResController.js
+    connectionArray.push(openConnectionObj);
+
+    let isSSE;
+
+    reqStream.on("response", (headers, flags) => {
+      // first argumnet of callback to response listener in ClientHttp2Stream is an object containing the receieved HTTP/2 Headers Object, as well as the flags associated with those headers
+
+      // SSE will have 'stream' in the 'content-type' heading
+      isSSE = headers["content-type"].includes("stream");
+
+      if (isSSE) {
+        reqResObj.connection = "open";
+        reqResObj.connectionType = "SSE";
+      } else {
+        reqResObj.connection = "closed";
+        reqResObj.connectionType = "plain";
+      }
+      reqResObj.isHTTP2 = true;
+      reqResObj.timeReceived = Date.now();
+      // for purpose of explaining time bug
+      console.log('this is the time inside the response event listener : ', Date.now())
+      reqResObj.response.headers = headers;
+
+      // if cookies exists, parse the cookie(s)
+      if (setCookie.parse(headers["set-cookie"])) {
+        console.log('made it into cookies')
+        reqResObj.response.cookies = this.cookieFormatter(
+          setCookie.parse(headers["set-cookie"])
+        );
+        // send back reqResObj to renderer so it can update the redux store
+        event.sender.send('reqResUpdate', reqResObj);
+
+        this.handleSingleEvent([], reqResObj, event);
+      }
+    });
+
+    reqStream.setEncoding("utf8");
+    let data = "";
+    reqStream.on("data", (chunk) => {
+      console.log('is this a server sent event? ', isSSE)
+      data += chunk;
+      if (isSSE) {
+        let couldBeEvents = true;
+        const wouldBeTimeReceived = Date.now();
+
+        while (couldBeEvents) {
+          const possibleEventArr = data.match(/[\s\S]*\n\n/g);
+
+          // if the array has a match, send it to be parsed, and send back to store
+          if (possibleEventArr && possibleEventArr[0]) {
+            const receivedEventFields = httpController.parseSSEFields(
+              possibleEventArr[0]
+            );
+            receivedEventFields.timeReceived = wouldBeTimeReceived;
+
+            reqResObj.response.events.push(receivedEventFields);
+            // send back reqResObj to renderer so it can update the redux store
+            event.sender.send('reqResUpdate', reqResObj);
+
+            // splice possibleEventArr, recombine with \n\n to reconstruct original,
+            // minus what was already parsed.
+            possibleEventArr.splice(0, 1);
+            data = possibleEventArr.join("\n\n");
+          }
+          // if does not contain, end while loop
+          else {
+            couldBeEvents = false;
+          }
+        }
+      }
+    });
+    reqStream.on("end", () => {
+      if (isSSE) {
+        const receivedEventFields = this.parseSSEFields(data);
+      
+        receivedEventFields.timeReceived = Date.now();
+        reqResObj.connection = "closed";
+        reqResObj.response.events.push(receivedEventFields);
+        // send back reqResObj to renderer so it can update the redux store
+        event.sender.send('reqResUpdate', reqResObj);
+      } else {
+        reqResObj.connection = "closed";
+        reqResObj.response.events.push(data);
+        // send back reqResObj to renderer so it can update the redux store
+        event.sender.send('reqResUpdate', reqResObj);
+      }
+    });
+  },
+  // ----------------------------------------------------------------------------
+
+  // sendToMainForFetch(args) {
+  //   return new Promise((resolve) => {
+  //     ipcRenderer.send("http1-fetch-message", args);
+  //     ipcRenderer.on("http1-fetch-reply", (event, result) => {
+  //       resolve(result);
+  //     });
+  //   });
+  // },
+
+  // ----------------------------------------------------------------------------
+
+  establishHTTP1connection(event, reqResObj, connectionArray) {
+    //XXXXXXXXXXXXXXX
+
+    // start off by clearing existing response data
+    reqResObj.response.headers = {};
+    reqResObj.response.events = [];
+    reqResObj.connection = "pending";
+    reqResObj.timeSent = Date.now();
+    // send back reqResObj to renderer so it can update the redux store
+    event.sender.send('reqResUpdate', reqResObj);
+
+    connectionArray.forEach((obj, i) => {
+      if (obj.id === reqResObj.id) {
+        connectionArray.splice(i, 1);
+      }
+    });
+    const openConnectionObj = {
+      abort: new AbortController(),
+      protocol: "HTTP1",
+      id: reqResObj.id,
+    };
+    connectionArray.push(openConnectionObj);
+
+    const options = this.parseFetchOptionsFromReqRes(reqResObj);
+    options.signal = openConnectionObj.abort.signal;
+
+    //--------------------------------------------------------------------------------------------------------------
+    // Check if the URL provided is a stream
+    //--------------------------------------------------------------------------------------------------------------
+
+    // if isSSE is true, then node-fetch to stream,
+    if (reqResObj.request.isSSE) {
+      // invoke another func that fetches to SSE and reads stream
+      // params: method, headers, body
+      const { method, headers, body } = options;
+
+      fetch2(headers.url, { method, headers, body }).then((response) => {
+        const heads = {};
+        for (const entry of response.headers.entries()) {
+          heads[entry[0].toLowerCase()] = entry[1];
+        }
+        reqResObj.response.headers = heads;
+        this.handleSSE(response, reqResObj, heads);
+      });
+    }
+    // if not SSE, talk to main to fetch data and receive
+    else {
+      // send information to the NODE side to do the fetch request
+      this.sendToMainForFetch({ options })
+        .then((response) => {
+          // Parse response headers now to decide if SSE or not.
+          const heads = response.headers;
+          reqResObj.response.headers = heads;
+
+          reqResObj.timeReceived = Date.now();
+          // send back reqResObj to renderer so it can update the redux store
+          event.sender.send('reqResUpdate', reqResObj);
+
+          const theResponseHeaders = response.headers;
+
+          const { body } = response;
+          reqResObj.response.headers = theResponseHeaders;
+
+          // if cookies exists, parse the cookie(s)
+          if (setCookie.parse(theResponseHeaders.cookies)) {
+            reqResObj.response.cookies = this.cookieFormatter(
+              setCookie.parse(theResponseHeaders.cookies)
+            );
+            // send back reqResObj to renderer so it can update the redux store
+            event.sender.send('reqResUpdate', reqResObj);
+
+            this.handleSingleEvent(body, reqResObj, event);
+          }
+        })
+        .catch((err) => {
+          reqResObj.connection = "error";
+          // send back reqResObj to renderer so it can update the redux store
+          event.sender.send('reqResUpdate', reqResObj);
+        });
+    }
+  },
+
+  // ----------------------------------------------------------------------------
+
+  parseFetchOptionsFromReqRes(reqResObject) {
+    const { headers, body, cookies } = reqResObject.request;
+    let { method } = reqResObject.request;
+
+    method = method.toUpperCase();
+
+    const formattedHeaders = {
+      url: reqResObject.url,
+    };
+    headers.forEach((head) => {
+      if (head.active) {
+        formattedHeaders[head.key] = head.value;
+      }
+    });
+
+    cookies.forEach((cookie) => {
+      const cookieString = `${cookie.key}=${cookie.value}`;
+      // attach to formattedHeaders so options object includes this
+      formattedHeaders.cookie = cookieString;
+    });
+
+    const outputObj = {
+      method,
+      mode: "cors", // no-cors, cors, *same-origin
+      cache: "no-cache", // *default, no-cache, reload, force-cache, only-if-cached
+      credentials: "include", // include, *same-origin, omit
+      headers: formattedHeaders,
+      redirect: "follow", // manual, *follow, error
+      referrer: "no-referrer", // no-referrer, *client
+    };
+
+    if (method !== "GET" && method !== "HEAD") {
+      outputObj.body = body;
+    }
+
+    return outputObj;
+  },
+
+  // ----------------------------------------------------------------------------
+
+  handleSingleEvent(response, reqResObj, event) {
+    const newObj = JSON.parse(JSON.stringify(reqResObj));
+    newObj.connection = "closed";
+    newObj.connectionType = "plain";
+    newObj.timeReceived = Date.now();
+    console.log('Date.now() inside handleSingleEvent : ', Date.now())
+    console.log('this is what was added : ', newObj.timeReceived)
+    newObj.response.events.push(response);
+    // send back reqResObj to renderer so it can update the redux store
+    event.sender.send('reqResUpdate', reqResObj);
+  },
+
+  // ----------------------------------------------------------------------------
+
+  /* handle SSE Streams for HTTP1.1 */
+  handleSSE(response, originalObj, headers) {
+    const reader = response.body.getReader();
+    let data = "";
+    read();
+
+    const newObj = JSON.parse(JSON.stringify(originalObj));
+
+    // okay to set these after the read since read is async
+    newObj.timeReceived = Date.now();
+    newObj.response.headers = headers;
+    newObj.response.events = [];
+    newObj.connection = "open";
+    newObj.connectionType = "SSE";
+
+    const decoder = new TextDecoder("utf-8");
+    function read() {
+      reader.read().then((obj) => {
+        // check if there is new info to add to data
+        if (decoder.decode(obj.value) !== "") {
+          data += decoder.decode(obj.value);
+        }
+
+        // check if there are double new lines to parse...
+        let couldBeEvents = true;
+        const wouldBeTimeReceived = Date.now();
+        while (couldBeEvents) {
+          const possibleEventArr = data.split(/\n\n/g);
+
+          // if the array has a match, send it to be parsed, and send back to store
+          if (possibleEventArr && possibleEventArr[0]) {
+            const receivedEventFields = httpController.parseSSEFields(
+              possibleEventArr[0]
+            );
+            receivedEventFields.timeReceived = wouldBeTimeReceived;
+
+            newObj.response.events.push(receivedEventFields);
+            store.default.dispatch(actions.reqResUpdate(newObj));
+
+            // splice possibleEventArr, recombine with \n\n to reconstruct original,
+            // minus what was already parsed.
+            possibleEventArr.splice(0, 1);
+            data = possibleEventArr.join("\n\n");
+          }
+          // if does not contain, end while loop
+          else {
+            couldBeEvents = false;
+          }
+        }
+
+        // base case
+        if (obj.done) {
+        } else {
+          read();
+        }
+      });
+    }
+  },
+
+  parseSSEFields(rawString) {
+    return (
+      rawString
+        // since the string is multi line, each for a different field, split by line
+        .split("\n")
+        // remove empty lines
+        .filter((field) => field !== "")
+        // massage fields so they can be parsed into JSON
+        .map((field) => {
+          const fieldColonSplit = field
+            .replace(/:/, "&&&&")
+            .split("&&&&")
+            .map((kv) => kv.trim());
+
+          const fieldObj = {
+            [fieldColonSplit[0]]: fieldColonSplit[1],
+          };
+          return fieldObj;
+        })
+        .reduce((acc, cur) => {
+          // handles if there are multiple fields of the same type, for example two data fields.
+          const key = Object.keys(cur)[0];
+          if (acc[key]) {
+            acc[key] = `${acc[key]}\n${cur[key]}`;
+          } else {
+            acc[key] = cur[key];
+          }
+          return acc;
+        }, {})
+    );
+  },
+
+  cookieFormatter(cookieArray) {
+    return cookieArray.map((eachCookie) => {
+      const cookieFormat = {
+        name: eachCookie.name,
+        value: eachCookie.value,
+        domain: eachCookie.domain,
+        hostOnly: eachCookie.hostOnly ? eachCookie.hostOnly : false,
+        path: eachCookie.path,
+        secure: eachCookie.secure ? eachCookie.secure : false,
+        httpOnly: eachCookie.httpOnly ? eachCookie.httpOnly : false,
+        session: eachCookie.session ? eachCookie.session : false,
+        expriationDate: eachCookie.expires ? eachCookie.expires : "",
+      };
+      return cookieFormat;
+    });
+  },
+};
+
+module.exports = () => {
+  // creating our event listeners for IPC events
+  ipcMain.on('open-http', (event, reqResObj, connectionArray) => {
+    // we pass the event object into these controller functions so that we can invoke event.sender.send when we need to make response to renderer process
+    httpController.openHTTPconnection(event, reqResObj, connectionArray);
+  })
+}; 

--- a/main.js
+++ b/main.js
@@ -664,3 +664,6 @@ ipcMain.on("open-gql", (event, args) => {
       });
   }
 });
+
+// export main window so we can access ipcMain from other files
+module.exports = mainWindow; 

--- a/main.js
+++ b/main.js
@@ -45,6 +45,9 @@ const protoParserFunc = require("./src/client/protoParser.js");
 
 // require menu file
 require("./menu/mainMenu");
+// require http controller file
+require('./httpMainController.js')();
+
 
 // configure logging
 // autoUpdater.logger = log;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4910,7 +4910,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -6204,7 +6204,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -6241,7 +6241,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -7514,7 +7514,7 @@
     },
     "core-js": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-js-compat": {
@@ -7642,7 +7642,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -7655,7 +7655,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -8263,7 +8263,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -8492,7 +8492,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexer3": {
@@ -10023,7 +10023,7 @@
     },
     "event-stream": {
       "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
       "integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
       "requires": {
         "duplexer": "~0.1.1",
@@ -10776,7 +10776,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.6.4.tgz",
+          "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.6.4.tgz",
           "integrity": "sha1-9G8MdbeEH40gCzNIzU1pHVoJnRU=",
           "requires": {
             "jsonfile": "~1.0.1",
@@ -10787,17 +10787,17 @@
         },
         "jsonfile": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-1.0.1.tgz",
           "integrity": "sha1-6l7+QLg2kLmGZ2FKc5L8YOhCwN0="
         },
         "mkdirp": {
           "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
           "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
         },
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         }
       }
@@ -11169,7 +11169,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -16794,7 +16794,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "requires": {
         "through": "~2.3"
@@ -18653,7 +18653,7 @@
     },
     "react-textarea-autosize": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-6.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-6.1.0.tgz",
       "integrity": "sha512-F6bI1dgib6fSvG8so1HuArPUv+iVEfPliuLWusLF+gAKz0FbB4jLrWUrTAeq1afnPT2c9toEZYUdz/y1uKMy4A==",
       "requires": {
         "prop-types": "^15.6.0"
@@ -19322,7 +19322,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
           "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
         }
       }
@@ -19863,7 +19863,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -20369,7 +20369,7 @@
     },
     "split": {
       "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+      "resolved": "http://registry.npmjs.org/split/-/split-0.2.10.tgz",
       "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
       "requires": {
         "through": "2"
@@ -20478,7 +20478,7 @@
     },
     "stream-combiner": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "requires": {
         "duplexer": "~0.1.1"
@@ -21160,7 +21160,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }

--- a/preload.js
+++ b/preload.js
@@ -1,16 +1,17 @@
 const { ipcRenderer, contextBridge } = require("electron");
 
 contextBridge.exposeInMainWorld("api", {
-  send: (channel, data) => {
+  send: (channel, ...data) => {
     // allowlist channels
     const allowedChannels = [
       "toMain",
       "confirm-clear-history",
       "import-proto",
       "quit-and-install",
+      'open-http'
     ];
     if (allowedChannels.includes(channel)) {
-      ipcRenderer.send(channel, data);
+      ipcRenderer.send(channel, ...data);
     }
   },
   receive: (channel, cb) => {
@@ -22,6 +23,7 @@ contextBridge.exposeInMainWorld("api", {
       "clear-history-response",
       "proto-info",
       "message",
+      'testing'
     ];
     if (allowedChannels.includes(channel)) {
       ipcRenderer.on(channel, (event, ...args) => cb(...args));

--- a/preload.js
+++ b/preload.js
@@ -8,7 +8,7 @@ contextBridge.exposeInMainWorld("api", {
       "confirm-clear-history",
       "import-proto",
       "quit-and-install",
-      'open-http'
+      'open-http',
     ];
     if (allowedChannels.includes(channel)) {
       ipcRenderer.send(channel, ...data);
@@ -23,7 +23,7 @@ contextBridge.exposeInMainWorld("api", {
       "clear-history-response",
       "proto-info",
       "message",
-      'testing'
+      'reqResUpdate'
     ];
     if (allowedChannels.includes(channel)) {
       ipcRenderer.on(channel, (event, ...args) => cb(...args));

--- a/src/client/components/containers/App.jsx
+++ b/src/client/components/containers/App.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import "../../../assets/style/App.scss";
 const { api } = window;
-// import ContentsContainer from './ContentsContainer.jsx';
+import ContentsContainer from './ContentsContainer.jsx';
 // import ReqResCtrl from '../../controllers/reqResController';
 import SidebarContainer from "./SidebarContainer.jsx";
 import UpdatePopUpContainer from "./UpdatePopUpContainer.jsx";
@@ -56,7 +56,7 @@ class App extends Component {
       <div id="app">
         <UpdatePopUpContainer />
         <SidebarContainer />
-        {/* <ContentsContainer /> */}
+        <ContentsContainer />
       </div>
     );
   }

--- a/src/client/components/containers/ContentsContainer.jsx
+++ b/src/client/components/containers/ContentsContainer.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-import GraphContainer from './GraphContainer.jsx';
+// import GraphContainer from './GraphContainer.jsx';
 import ReqResContainer from './ReqResContainer.jsx';
 import NavBarContainer from './NavBarContainer.jsx';
 
@@ -12,7 +12,7 @@ class Contents extends Component {
   render() {
     return(
       <div className={'contents'}>
-        <GraphContainer/>
+        {/* <GraphContainer/> */}
         <NavBarContainer/>
         <ReqResContainer/>
       </div>

--- a/src/client/controllers/reqResController.js
+++ b/src/client/controllers/reqResController.js
@@ -50,6 +50,7 @@ const connectionController = {
   openReqRes(id) {
     // listens for reqResUpdate event from main process telling it to update reqResobj
     api.receive('reqResUpdate', (reqResObj) => store.default.dispatch(actions.reqResUpdate(reqResObj)));
+    
     const reqResArr = store.default.getState().business.reqResArray;
     const reqResObj = reqResArr.find((el) => el.id === id);
     if (reqResObj.request.method === "SUBSCRIPTION")

--- a/src/client/controllers/reqResController.js
+++ b/src/client/controllers/reqResController.js
@@ -48,7 +48,8 @@ const connectionController = {
   },
 
   openReqRes(id) {
-    console.log("this.openConnectionArray ->", this.openConnectionArray);
+    // listens for reqResUpdate event from main process telling it to update reqResobj
+    api.receive('reqResUpdate', (reqResObj) => store.default.dispatch(actions.reqResUpdate(reqResObj)));
     const reqResArr = store.default.getState().business.reqResArray;
     const reqResObj = reqResArr.find((el) => el.id === id);
     if (reqResObj.request.method === "SUBSCRIPTION")
@@ -59,8 +60,8 @@ const connectionController = {
       wsController.openWSconnection(reqResObj, this.openConnectionArray);
     else if (reqResObj.gRPC) grpcController.openGrpcConnection(reqResObj);
     else {
+      console.log('should be sending')
       api.send('open-http', reqResObj, this.openConnectionArray);
-      api.receive('testing', (data) => console.log('just received :  ', data))
       // httpController.openHTTPconnection(reqResObj, this.openConnectionArray);
     }
   },

--- a/src/client/controllers/reqResController.js
+++ b/src/client/controllers/reqResController.js
@@ -1,9 +1,11 @@
 import * as store from "../store";
 import * as actions from "../actions/actions";
-import httpController from "./httpController.js";
-import wsController from "./wsController.js";
-import graphQLController from "./graphQLController.js";
-import grpcController from "./grpcController.js";
+// import httpController from "./httpController.js";
+// import wsController from "./wsController.js";
+// import graphQLController from "./graphQLController.js";
+// import grpcController from "./grpcController.js";
+
+const { api } = window; 
 
 const connectionController = {
   openConnectionArray: [],
@@ -57,7 +59,9 @@ const connectionController = {
       wsController.openWSconnection(reqResObj, this.openConnectionArray);
     else if (reqResObj.gRPC) grpcController.openGrpcConnection(reqResObj);
     else {
-      httpController.openHTTPconnection(reqResObj, this.openConnectionArray);
+      api.send('open-http', reqResObj, this.openConnectionArray);
+      api.receive('testing', (data) => console.log('just received :  ', data))
+      // httpController.openHTTPconnection(reqResObj, this.openConnectionArray);
     }
   },
 


### PR DESCRIPTION
## Description:
- I refactored the HTTP Controller file so that it works entirely in the main process. I only did this for the HTTP2-related functionality, but will finish the HTTP portion soon. 
## Changes I Made:
- The reqResController.js file now sends an event over IPC to the main process to open and http channel. The mainProcess is listening for this event, and does all the logic to do so (creating a client, opening a connection, etc.) in the main process in the HTTPControllerMain.js file. Whenever the reqResObj is updated and needs to be added to the redux store, the main process sends an event across the 'reqResUpdate' channel, passing in the updated reqRes Obj. The renderer process is listening for such an event, and dispatches the resResUpdate action to the store, passing in the received reqResObj. This happens whenever the reqResObj gets updated during the HTTP request/response process. 

-I also figured out a way to add the HTTPController to the main process without further bloating the main.js file. From the  HTTPControllerMain.js file, I export a function that, when invoked, creates an event-listener on ipcMain. I then require that file into the main.js file, and immediately invoke it, creating an event listener. 
-
## How to Test:
-See if the app works as before. NOTE: only the HTTP2 connections still work for now. Also, I do not yet know how to test for SSE. These are things I will be working on next. Ideally, there will also be some sort of automated end-to-end testing that can test this part of the app for us. 