### PR TITLE
Refactor HTTP Controller and SSE to disallow Node Integration

### DIFF
--- a/SSEController.js
+++ b/SSEController.js
@@ -1,6 +1,7 @@
 
 const { ipcMain }  = require('electron');
 const EventSource = require('eventsource');
+const fetch = require('node-fetch');
 const http = require('http');
 
 const SSEController = {};
@@ -15,15 +16,16 @@ SSEController.testing = (url, reqResObj, event) => {
   console.log('fired!!')
   sse.onopen = () => console.log('opened bitch!');
   sse.onmessage = (message) => {
-    console.log('received message')
-    message.timeReceived = Date.now(); 
+    const newMessage = { ...message };
+    newMessage.timeReceived = Date.now(); 
     // FIX THIS LATER!!!
     if (!reqResObj.response.events) reqResObj.response.events = []; 
-    reqResObj.response.events.push(message);
+    reqResObj.response.events.push(newMessage);
     reqResObj.response.headers = {};
+    reqResObj.connection = 'initialized';
     reqResObj.response.headers['content-type'] = 'text/event-stream'
     console.log('created this : ', reqResObj.response)
-    event.sender.send('reqResUpdate', JSON.parse(reqResObj));
+    event.sender.send('reqResUpdate', reqResObj);
     counter++; 
     if (counter === 5) sse.close(); 
   }; 
@@ -37,11 +39,48 @@ SSEController.testing = (url, reqResObj, event) => {
   // })
 }
 
-module.exports = () => {
-  // creating our event listeners for IPC events
-  ipcMain.on('testing-SSE', (event, url, reqResObj) => {
-    console.log('received!!!')
-    // we pass the event object into these controller functions so that we can invoke event.sender.send when we need to make response to renderer process
-    SSEController.testing(url, reqResObj, event);
-  })
-}; 
+SSEController.createStream = (reqResObj, options, event) => {
+  
+  const { headers } = options;
+  const startTime = Date.now(); 
+
+  http.get(headers.url, {
+    headers,
+    agent: false,
+  }, (res) => {
+    console.log('res is : ', res)
+    reqResObj.response.headers = {...res.headers};
+    reqResObj.connection = 'open'; 
+    reqResObj.connectionType = 'SSE';
+    SSEController.readStream(reqResObj, event, Date.now() - startTime);
+    // res.on('data', (chunk) => {
+    //   console.log(res.headers)
+    //   event.sender.send('testing-SSE', chunk.toString()); 
+    // });
+  });
+};
+
+SSEController.readStream = (reqResObj, event, timeDiff) => {
+  sse = new EventSource(reqResObj.url); 
+  console.log('fired!!')
+  sse.onopen = () => console.log('opened!');
+  sse.onmessage = (message) => {
+    const newMessage = { ...message };
+    newMessage.timeReceived = Date.now() - timeDiff; 
+    // FIX THIS LATER!!!
+    reqResObj.response.events.push(newMessage);
+    // console.log('created this : ', newMessage.data, newMessage.timeReceived)
+    event.sender.send('reqResUpdate', reqResObj);
+  }; 
+}
+
+// module.exports = () => {
+//   // creating our event listeners for IPC events
+//   ipcMain.on('testing-SSE', (event, url, reqResObj) => {
+//     console.log('received!!!')
+//     // we pass the event object into these controller functions so that we can invoke event.sender.send when we need to make response to renderer process
+//     SSEController.testing(url, reqResObj, event);
+//   })
+// }; 
+
+module.exports = SSEController; 

--- a/SSEController.js
+++ b/SSEController.js
@@ -44,11 +44,11 @@ SSEController.createStream = (reqResObj, options, event) => {
   const { headers } = options;
   const startTime = Date.now(); 
 
-  http.get(headers.url, {
+  const req = http.get(headers.url, {
     headers,
     agent: false,
   }, (res) => {
-    console.log('res is : ', res)
+    console.log('made request')
     reqResObj.response.headers = {...res.headers};
     reqResObj.connection = 'open'; 
     reqResObj.connectionType = 'SSE';
@@ -57,21 +57,25 @@ SSEController.createStream = (reqResObj, options, event) => {
     //   console.log(res.headers)
     //   event.sender.send('testing-SSE', chunk.toString()); 
     // });
+    req.end()
   });
 };
 
 SSEController.readStream = (reqResObj, event, timeDiff) => {
   sse = new EventSource(reqResObj.url); 
-  console.log('fired!!')
   sse.onopen = () => console.log('opened!');
   sse.onmessage = (message) => {
+
     const newMessage = { ...message };
     newMessage.timeReceived = Date.now() - timeDiff; 
     // FIX THIS LATER!!!
     reqResObj.response.events.push(newMessage);
     // console.log('created this : ', newMessage.data, newMessage.timeReceived)
-    event.sender.send('reqResUpdate', reqResObj);
+    return event.sender.send('reqResUpdate', reqResObj);
   }; 
+sse.onerror = (err) => {
+  console.log('there was an error in SSEController.readStream', err)
+}
 }
 
 // module.exports = () => {

--- a/SSEController.js
+++ b/SSEController.js
@@ -1,0 +1,47 @@
+
+const { ipcMain }  = require('electron');
+const EventSource = require('eventsource');
+const http = require('http');
+
+const SSEController = {};
+
+let sse; 
+
+SSEController.testing = (url, reqResObj, event) => {
+  // console.log('event before function :', event)
+  console.log('reqresobj : ', reqResObj)
+  let counter = 0; 
+  sse = new EventSource(url); 
+  console.log('fired!!')
+  sse.onopen = () => console.log('opened bitch!');
+  sse.onmessage = (message) => {
+    console.log('received message')
+    message.timeReceived = Date.now(); 
+    // FIX THIS LATER!!!
+    if (!reqResObj.response.events) reqResObj.response.events = []; 
+    reqResObj.response.events.push(message);
+    reqResObj.response.headers = {};
+    reqResObj.response.headers['content-type'] = 'text/event-stream'
+    console.log('created this : ', reqResObj.response)
+    event.sender.send('reqResUpdate', JSON.parse(reqResObj));
+    counter++; 
+    if (counter === 5) sse.close(); 
+  }; 
+  // http.get(url, {
+  //   agent: false
+  // }, (res) => {
+  //   res.on('data', (chunk) => {
+  //     console.log(res.headers)
+  //     event.sender.send('testing-SSE', chunk.toString()); 
+  //   })
+  // })
+}
+
+module.exports = () => {
+  // creating our event listeners for IPC events
+  ipcMain.on('testing-SSE', (event, url, reqResObj) => {
+    console.log('received!!!')
+    // we pass the event object into these controller functions so that we can invoke event.sender.send when we need to make response to renderer process
+    SSEController.testing(url, reqResObj, event);
+  })
+}; 

--- a/httpMainController.js
+++ b/httpMainController.js
@@ -8,6 +8,7 @@ const http2 = require("http2");
 const setCookie = require("set-cookie-parser");
 
 //Included Functions
+const SSEController = require('./SSEController'); 
 
 // openHTTPconnection(reqResObj, connectionArray)
 // establishHTTP2Connection(reqResObj, connectionArray)
@@ -79,9 +80,9 @@ const httpController = {
     // --------------------------------------------------
     else {
       // console.log('New HTTP2 Conn:', reqResObj.host);
-
+      console.log('no pre-existing http2 found')
       const id = Math.random() * 100000;
-      const client = http2.connect(reqResObj.host);
+      const client = http2.connect(reqResObj.host, () => console.log('connected!'));
 
       // push HTTP2 connection to array
       const http2Connection = {
@@ -335,19 +336,20 @@ const httpController = {
     if (reqResObj.request.isSSE) {
       // invoke another func that fetches to SSE and reads stream
       // params: method, headers, body
-      const { method, headers, body } = options;
-      console.log('just tracing the path....')
-      fetch2(headers.url, { method, headers, body })
-        .then((response) => {
-          const heads = {};
-          for (const entry of response.headers.entries()) {
-            heads[entry[0].toLowerCase()] = entry[1];
-          }
-          reqResObj.response.headers = heads;
-          console.log('response is: ', response, 'reqResObj is :', reqResObj)
-          this.handleSSE(response, reqResObj, heads);
-        })
-        .catch((err) => console.log('there was an error, ', err))
+      SSEController.createStream(reqResObj, options, event)
+      // const { method, headers, body } = options;
+      // console.log('just tracing the path....')
+      // fetch2(headers.url, { method, headers, body })
+      //   .then((response) => {
+      //     const heads = {};
+      //     for (const entry of response.headers.entries()) {
+      //       heads[entry[0].toLowerCase()] = entry[1];
+      //     }
+      //     reqResObj.response.headers = heads;
+      //     console.log('response is: ', response, 'reqResObj is :', reqResObj)
+      //     this.handleSSE(response, reqResObj, heads);
+      //   })
+      //   .catch((err) => console.log('there was an error, ', err))
 
     }
     // if not SSE, talk to main to fetch data and receive

--- a/main.js
+++ b/main.js
@@ -47,7 +47,7 @@ const protoParserFunc = require("./src/client/protoParser.js");
 require("./menu/mainMenu");
 // require http controller file
 require('./httpMainController.js')();
-require('./SSEController.js')();
+// require('./SSEController.js')();
 
 
 // configure logging

--- a/main.js
+++ b/main.js
@@ -47,6 +47,7 @@ const protoParserFunc = require("./src/client/protoParser.js");
 require("./menu/mainMenu");
 // require http controller file
 require('./httpMainController.js')();
+require('./SSEController.js')();
 
 
 // configure logging

--- a/package-lock.json
+++ b/package-lock.json
@@ -15434,7 +15434,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
       "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
-      "dev": true,
       "requires": {
         "original": "^1.0.0"
       }
@@ -21999,7 +21998,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
       "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-      "dev": true,
       "requires": {
         "url-parse": "^1.4.3"
       }
@@ -23904,8 +23902,7 @@
     "querystringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-      "dev": true
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "raf": {
       "version": "3.4.1",
@@ -24635,8 +24632,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.11.1",
@@ -27321,7 +27317,6 @@
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "electron-log": "^4.2.2",
     "electron-updater": "^4.3.1",
     "es6-promise": "^4.2.8",
+    "eventsource": "^1.0.7",
     "express": "^4.17.1",
     "google-auth-library": "^6.0.2",
     "graphql": "^14.6.0",

--- a/preload.js
+++ b/preload.js
@@ -12,7 +12,6 @@ contextBridge.exposeInMainWorld("api", {
       "import-collection",
       "export-collection",
       'open-http',
-      'testing-SSE'
     ];
     if (allowedChannels.includes(channel)) {
       ipcRenderer.send(channel, ...data);
@@ -29,7 +28,6 @@ contextBridge.exposeInMainWorld("api", {
       "message",
       "reply-gql",
       'reqResUpdate',
-      'testing-SSE'
     ];
     if (allowedChannels.includes(channel)) {
       ipcRenderer.on(channel, (event, ...args) => cb(...args));

--- a/preload.js
+++ b/preload.js
@@ -12,6 +12,7 @@ contextBridge.exposeInMainWorld("api", {
       "import-collection",
       "export-collection",
       'open-http',
+      'testing-SSE'
     ];
     if (allowedChannels.includes(channel)) {
       ipcRenderer.send(channel, ...data);
@@ -27,7 +28,8 @@ contextBridge.exposeInMainWorld("api", {
       "proto-info",
       "message",
       "reply-gql",
-      'reqResUpdate'
+      'reqResUpdate',
+      'testing-SSE'
     ];
     if (allowedChannels.includes(channel)) {
       ipcRenderer.on(channel, (event, ...args) => cb(...args));

--- a/src/client/components/containers/ReqResContainer.jsx
+++ b/src/client/components/containers/ReqResContainer.jsx
@@ -25,6 +25,7 @@ class ReqResContainer extends Component {
   render() {
     const reqResArr = this.props.reqResArray
       .map((reqRes, index) => {
+        // console.log('from the sto : ', reqRes.response)
         return <SingleReqResContainer
           className="reqResChild"
           content={reqRes}

--- a/src/client/components/display/ResponseEventsDisplay.jsx
+++ b/src/client/components/display/ResponseEventsDisplay.jsx
@@ -12,8 +12,9 @@ const ResponseEventsDisplay = ({ response }) => {
   if (
     headers &&
     headers["content-type"] &&
-    headers["content-type"].includes("text/event-stream")
+    headers["content-type"] === "text/event-stream"
   ) {
+    console.log('we have a match!!!')
     events.forEach((cur, idx) => {
       displayContents.push(<SSERow key={idx} content={cur} />);
     });

--- a/src/client/components/display/ResponseEventsDisplay.jsx
+++ b/src/client/components/display/ResponseEventsDisplay.jsx
@@ -8,13 +8,12 @@ const ResponseEventsDisplay = ({ response }) => {
   const displayContents = [];
 
   // If it's an SSE, render event rows
-
+  console.log('response is : ', response, 'headers is : ', headers)
   if (
     headers &&
     headers["content-type"] &&
     headers["content-type"] === "text/event-stream"
   ) {
-    console.log('we have a match!!!')
     events.forEach((cur, idx) => {
       displayContents.push(<SSERow key={idx} content={cur} />);
     });

--- a/src/client/components/display/SSERow.jsx
+++ b/src/client/components/display/SSERow.jsx
@@ -29,13 +29,13 @@ class SSERow extends Component {
         <div className={'grid-4'}>
           <div>
             <span className="tertiary-title">
-              ID {this.props.content.id}
+              ID {this.props.content.lastEventId}
             </span>
           </div>
 
           <div>
             <span className="tertiary-title">
-              Event {this.props.content.event}
+              Event {this.props.content.type}
             </span>
           </div>
 
@@ -53,7 +53,7 @@ class SSERow extends Component {
         <div className={'title-row data-inner'}>
           <div>
             <span className={'tertiary-title'}>
-              Data {contentBody}
+              Data: {contentBody}
             </span>
           </div>
         </div>

--- a/src/client/controllers/reqResController.js
+++ b/src/client/controllers/reqResController.js
@@ -50,7 +50,7 @@ const connectionController = {
   openReqRes(id) {
     // listens for reqResUpdate event from main process telling it to update reqResobj
     api.receive('reqResUpdate', (reqResObj) => store.default.dispatch(actions.reqResUpdate(reqResObj)));
-     api.receive('testing-SSE', (data) => console.log('just got back :', data))
+    
     const reqResArr = store.default.getState().business.reqResArray;
     const reqResObj = reqResArr.find((el) => el.id === id);
     if (reqResObj.request.method === "SUBSCRIPTION")
@@ -60,15 +60,6 @@ const connectionController = {
     else if (/wss?:\/\//.test(reqResObj.protocol))
       wsController.openWSconnection(reqResObj, this.openConnectionArray);
     else if (reqResObj.gRPC) grpcController.openGrpcConnection(reqResObj);
-    // else if (reqResObj.request.isSSE) {
-    //   // events = new EventSource(reqResObj.url); 
-    //   // events.onopen = () => console.log('opeend!');
-    //   // events.onmessage = function(event){
-
-    //   //   console.log(event)
-    //   // };
-    //  api.receive('testing-SSE', (data) => console.log('just got back :', data))
-    //  api.send('testing-SSE', reqResObj.url, reqResObj); 
     else {
       // sends request to main process to open an http connections
       api.send('open-http', reqResObj, this.openConnectionArray);

--- a/src/client/controllers/reqResController.js
+++ b/src/client/controllers/reqResController.js
@@ -6,7 +6,7 @@ import * as actions from "../actions/actions";
 // import grpcController from "./grpcController.js";
 
 const { api } = window; 
-
+let events; 
 const connectionController = {
   openConnectionArray: [],
   // selectedArray:[],
@@ -60,10 +60,18 @@ const connectionController = {
     else if (/wss?:\/\//.test(reqResObj.protocol))
       wsController.openWSconnection(reqResObj, this.openConnectionArray);
     else if (reqResObj.gRPC) grpcController.openGrpcConnection(reqResObj);
-    else {
-      console.log('should be sending')
+    else if (reqResObj.request.isSSE) {
+      // events = new EventSource(reqResObj.url); 
+      // events.onopen = () => console.log('opeend!');
+      // events.onmessage = function(event){
+
+      //   console.log(event)
+      // };
+     api.receive('testing-SSE', (data) => console.log('just got back :', data))
+     api.send('testing-SSE', reqResObj.url, reqResObj); 
+    } else {
+      // sends request to main process to open an http connections
       api.send('open-http', reqResObj, this.openConnectionArray);
-      // httpController.openHTTPconnection(reqResObj, this.openConnectionArray);
     }
   },
 

--- a/src/client/controllers/reqResController.js
+++ b/src/client/controllers/reqResController.js
@@ -50,7 +50,7 @@ const connectionController = {
   openReqRes(id) {
     // listens for reqResUpdate event from main process telling it to update reqResobj
     api.receive('reqResUpdate', (reqResObj) => store.default.dispatch(actions.reqResUpdate(reqResObj)));
-    
+     api.receive('testing-SSE', (data) => console.log('just got back :', data))
     const reqResArr = store.default.getState().business.reqResArray;
     const reqResObj = reqResArr.find((el) => el.id === id);
     if (reqResObj.request.method === "SUBSCRIPTION")
@@ -60,16 +60,16 @@ const connectionController = {
     else if (/wss?:\/\//.test(reqResObj.protocol))
       wsController.openWSconnection(reqResObj, this.openConnectionArray);
     else if (reqResObj.gRPC) grpcController.openGrpcConnection(reqResObj);
-    else if (reqResObj.request.isSSE) {
-      // events = new EventSource(reqResObj.url); 
-      // events.onopen = () => console.log('opeend!');
-      // events.onmessage = function(event){
+    // else if (reqResObj.request.isSSE) {
+    //   // events = new EventSource(reqResObj.url); 
+    //   // events.onopen = () => console.log('opeend!');
+    //   // events.onmessage = function(event){
 
-      //   console.log(event)
-      // };
-     api.receive('testing-SSE', (data) => console.log('just got back :', data))
-     api.send('testing-SSE', reqResObj.url, reqResObj); 
-    } else {
+    //   //   console.log(event)
+    //   // };
+    //  api.receive('testing-SSE', (data) => console.log('just got back :', data))
+    //  api.send('testing-SSE', reqResObj.url, reqResObj); 
+    else {
       // sends request to main process to open an http connections
       api.send('open-http', reqResObj, this.openConnectionArray);
     }

--- a/test/fakeSEEServer.js
+++ b/test/fakeSEEServer.js
@@ -1,6 +1,7 @@
 const http = require('http');
 
 http.createServer((request, response) => {
+  // these headers tell our 'browser' to keep the connection open
   response.writeHead(200, {
     'Connection': 'keep-alive',
     'Content-Type': 'text/event-stream',
@@ -13,6 +14,7 @@ http.createServer((request, response) => {
 
 }).listen(5001, () => console.log('server listening on port 5001'));
 
+// this function sends messages every 3 seconds 
 const sendSSEs = (response, id = 0, timeout) => {
   response.write(
     `id: ${id}\ndata: This is event ${id}\n\n`

--- a/test/fakeSEEServer.js
+++ b/test/fakeSEEServer.js
@@ -1,0 +1,20 @@
+const http = require('http');
+
+http.createServer((request, response) => {
+  response.writeHead(200, {
+    'Connection': 'keep-alive',
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Access-Control-Allow-Origin': '*'
+  });
+  let id = 1;
+  // Send event every 3 seconds or so forever...
+  setInterval(() => {
+    console.log('sending')
+    response.write(
+      `id: ${id}\ndata: This is event ${id}\n\n`
+    );
+    response.write('\n\n');
+    id++;
+  }, 3000);
+}).listen(5001, () => console.log('server listening on port 5001'));

--- a/test/fakeSEEServer.js
+++ b/test/fakeSEEServer.js
@@ -16,5 +16,5 @@ http.createServer((request, response) => {
     );
     response.write('\n\n');
     id++;
-  }, 3000);
+  }, 6000);
 }).listen(5001, () => console.log('server listening on port 5001'));

--- a/test/fakeSEEServer.js
+++ b/test/fakeSEEServer.js
@@ -7,14 +7,21 @@ http.createServer((request, response) => {
     'Cache-Control': 'no-cache',
     'Access-Control-Allow-Origin': '*'
   });
-  let id = 1;
-  // Send event every 3 seconds or so forever...
-  setInterval(() => {
-    console.log('sending')
-    response.write(
-      `id: ${id}\ndata: This is event ${id}\n\n`
-    );
-    response.write('\n\n');
-    id++;
-  }, 6000);
+  
+  sendSSEs(response); 
+  
+
 }).listen(5001, () => console.log('server listening on port 5001'));
+
+const sendSSEs = (response, id = 0, timeout) => {
+  response.write(
+    `id: ${id}\ndata: This is event ${id}\n\n`
+  );
+  id++; 
+
+  if (id < 6) {
+    timeout = setTimeout(() => {
+      sendSSEs(response, id, timeout);
+    }, 3000)
+  };
+} 


### PR DESCRIPTION
**Description:**
-I refactored the HTTP controller to use IPC between main and render processes instead of node functionality in the renderer process, as well as modularizing the pars of the HTTP Controller that deal with Server-Sent Events. To test the SSE functionality, I created a mock SSE server that sends messages every few seconds.

**Changes I Made:**
Removed a significant portion of the SSE parts of HTTP Controller into a new file, SSEController.
I deleted the SSE functionality that parsed SSE fields and handled SSE, as I either rewrote those parts in the new file, or, as was the case with the parsing, that functionality happens automatically with the EventSource API.
Utilized the API we created in our context-bridge to remove node-related functionality from the renderer process into the main process.
Moved the HTTPController.js file into the root directory, renamed it HTTPMainController. The old file is still there, for reference.
**How to Test:**
Use the app! In the future, we will be automating the spinning up of the mock server so we can do end-to-end testing of these components with Spectron.