### PR TITLE
fix cm variables box, refactor

### DIFF
--- a/src/client/components/composer/NewRequest/ComposerNewRequest.jsx
+++ b/src/client/components/composer/NewRequest/ComposerNewRequest.jsx
@@ -66,6 +66,14 @@ class ComposerNewRequest extends Component {
   addNewRequest() {
     const validated = this.requestValidationCheck();
     if (Object.keys(validated).length === 0) {
+
+      const { 
+        newRequestBody: { 
+          bodyContent, 
+          bodyVariables 
+        }
+      } = this.props;
+      
       let reqRes;
       const protocol = this.props.newRequestFields.gRPC
         ? ""
@@ -87,14 +95,6 @@ class ComposerNewRequest extends Component {
           path = path.substring(0, path.length - 1);
         }
         path = path.replace(/https?:\//g, "http://");
-        let historyBodyContent;
-        if (this.props.newRequestBody.bodyContent) {
-          historyBodyContent = this.props.newRequestBody.bodyContent;
-        } else historyBodyContent = "";
-        let historyBodyVariables;
-        if (this.props.newRequestBody.bodyContent) {
-          historyBodyContent = this.props.newRequestBody.bodyContent;
-        } else historyBodyVariables = "";
         reqRes = {
           id: uuid(),
           created_at: new Date(),
@@ -118,9 +118,9 @@ class ComposerNewRequest extends Component {
             cookies: this.props.newRequestCookies.cookiesArr.filter(
               (cookie) => cookie.active && !!cookie.key
             ),
-            body: historyBodyContent,
+            body: bodyContent || '',
             bodyType: this.props.newRequestBody.bodyType,
-            bodyVariables: historyBodyVariables,
+            bodyVariables: bodyVariables || '',
             rawType: this.props.newRequestBody.rawType,
             isSSE: this.props.newRequestSSE.isSSE,
           },
@@ -147,25 +147,6 @@ class ComposerNewRequest extends Component {
           path = path.substring(0, path.length - 1);
         }
         path = path.replace(/wss?:\//g, "ws://");
-        let historyBodyContent;
-        // don't think we need this conditional. bodyContent from state will be populated
-        // from the text entered in the "body" box onChange
-        if (document.querySelector("#gqlBodyEntryTextArea")) {
-          historyBodyContent = document.querySelector("#gqlBodyEntryTextArea")
-            .value;
-        } //grabs the input value in case tab was last key pressed
-        else if (this.props.newRequestBody.bodyContent) {
-          console.log('in the ws else if')
-          historyBodyContent = this.props.newRequestBody.bodyContent;
-        } else historyBodyContent = this.props.newRequestBody.bodyContent;
-        // historyBodyContent = "";
-        let historyBodyVariables;
-        if (document.querySelector("#gqlVariableEntryTextArea")) {
-          historyBodyVariables = document.querySelector(
-            "#gqlVariableEntryTextArea"
-          ).value;
-        } //grabs the input value in case tab was last key pressed
-        else historyBodyVariables = "";
         reqRes = {
           id: uuid(),
           created_at: new Date(),
@@ -188,9 +169,9 @@ class ComposerNewRequest extends Component {
             cookies: this.props.newRequestCookies.cookiesArr.filter(
               (cookie) => cookie.active && !!cookie.key
             ),
-            body: historyBodyContent,
+            body: bodyContent || '',
             bodyType: this.props.newRequestBody.bodyType,
-            bodyVariables: historyBodyVariables,
+            bodyVariables: bodyVariables || '',
             rawType: this.props.newRequestBody.rawType,
           },
           response: {

--- a/src/client/components/composer/NewRequest/FieldEntryForm.jsx
+++ b/src/client/components/composer/NewRequest/FieldEntryForm.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable default-case */
 import React, { useRef } from "react";
 import ProtocolSelect from "./ProtocolSelect.jsx";
 import colors from "../../../../assets/style/colors.scss";
@@ -43,6 +44,7 @@ const FieldEntryForm = (props) => {
             bodyContent: `query {
 
 }`,
+            bodyVariables: `# write any variables here!`
           });
           break;
         } else if (value === "http://") {
@@ -140,6 +142,7 @@ const FieldEntryForm = (props) => {
           props.setNewRequestBody({
             ...props.newRequestBody,
             bodyContent: newBody,
+            bodyIsNew: false,
           });
         } else if (value === "MUTATION") {
           newBody = methodReplaceRegex.test(props.newRequestBody.bodyContent)
@@ -152,6 +155,7 @@ const FieldEntryForm = (props) => {
           props.setNewRequestBody({
             ...props.newRequestBody,
             bodyContent: newBody,
+            bodyIsNew: false,
           });
         } else if (value === "SUBSCRIPTION") {
           newBody = methodReplaceRegex.test(props.newRequestBody.bodyContent)
@@ -164,6 +168,7 @@ const FieldEntryForm = (props) => {
           props.setNewRequestBody({
             ...props.newRequestBody,
             bodyContent: newBody,
+            bodyIsNew: false,
           });
         }
 

--- a/src/client/components/composer/NewRequest/GraphQLBodyEntryForm.jsx
+++ b/src/client/components/composer/NewRequest/GraphQLBodyEntryForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Controlled as CodeMirror } from "react-codemirror2";
 import "codemirror/addon/edit/matchbrackets";
 import "codemirror/addon/edit/closebrackets";
@@ -16,6 +16,7 @@ import dropDownArrow from "../../../../assets/icons/arrow_drop_down_white_192x19
 const GraphQLBodyEntryForm = (props) => {
   const {
     newRequestBody: { bodyContent },
+    newRequestBody: { bodyIsNew },
     newRequestBody,
     setNewRequestBody,
     stylesObj,
@@ -24,9 +25,10 @@ const GraphQLBodyEntryForm = (props) => {
   const [show, setShow] = useState(true);
   const [cmValue, setValue] = useState(bodyContent);
 
-  // useEffect(() => {
-  //   if (cmValue !== bodyContent) setValue(bodyContent)
-  // }, [bodyContent])
+  // set a new value for codemirror only if loading from history or changing query type
+  useEffect(() => {
+    if (!bodyIsNew) setValue(bodyContent)
+  }, [bodyContent])
 
   const arrowClass = show
     ? "composer_subtitle_arrow-open"
@@ -48,6 +50,8 @@ const GraphQLBodyEntryForm = (props) => {
         Body
       </div>
       <div className={bodyContainerClass} style={{ marginBottom: "10px" }}>
+        {/* conditional render to show custom keys for autocomplete */}
+        {/* {introspectionData.clientSchema ? <div>Press ___ to autocomplete</div> : '' } */}
         <CodeMirror
           value={cmValue}
           options={{
@@ -62,22 +66,26 @@ const GraphQLBodyEntryForm = (props) => {
             indentUnit: 2,
             tabSize: 2,
           }}
+          editorDidMount={editor => { editor.setSize('100%', 150) }}
           onBeforeChange={(editor, data, value) => {
+            const optionObj = {
+              schema: introspectionData.clientSchema,
+              // customKeys: {
+              //   Tab: 'defaultTab', 
+              //   Enter: 'newlineAndIndent', 
+              //   Alt: 'autocomplete'
+              // }
+            }
             setValue(value);
-            editor.setOption("lint", {
-              schema: introspectionData.clientSchema,
-            });
-            editor.setOption("hintOptions", {
-              schema: introspectionData.clientSchema,
-            });
+            editor.setOption("lint", optionObj);
+            editor.setOption("hintOptions", optionObj);
           }}
           onChange={(editor, data, value) => {
             editor.showHint();
-            // console.log('changing')
-            // console.log('value', value);
             setNewRequestBody({
               ...newRequestBody,
               bodyContent: value,
+              bodyIsNew: true,
             });
           }}
         />

--- a/src/client/components/composer/NewRequest/GraphQLVariableEntryForm.jsx
+++ b/src/client/components/composer/NewRequest/GraphQLVariableEntryForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Controlled as CodeMirror } from "react-codemirror2";
 import "codemirror/addon/edit/matchbrackets";
 import "codemirror/addon/edit/closebrackets";
@@ -10,12 +10,14 @@ import "codemirror-graphql/hint";
 import "codemirror-graphql/lint";
 import "codemirror-graphql/mode";
 import "codemirror/addon/lint/lint.css";
+import "codemirror/addon/display/autorefresh"
 
 import dropDownArrow from "../../../../assets/icons/arrow_drop_down_white_192x192.png";
 
 const GraphQLVariableEntryForm = (props) => {
   const {
     newRequestBody: { bodyVariables },
+    newRequestBody: { bodyIsNew },
     newRequestBody,
     setNewRequestBody,
     stylesObj,
@@ -24,9 +26,13 @@ const GraphQLVariableEntryForm = (props) => {
   const [show, setShow] = useState(false);
   const [cmValue, setValue] = useState(bodyVariables);
 
-  // useEffect(() => {
-  //   if (cmValue !== bodyVariables) setValue(bodyVariables)
-  // }, [bodyVariables])
+  // ref to get the codemirror instance
+  const cmVariables = useRef(null);
+
+  // set a new value for codemirror only if loading from history or changing gQL type
+  useEffect(() => {
+    if (!bodyIsNew) setValue(bodyVariables);
+  }, [bodyVariables])
 
   const arrowClass = show
     ? "composer_subtitle_arrow-open"
@@ -41,39 +47,38 @@ const GraphQLVariableEntryForm = (props) => {
         className="composer_subtitle"
         onClick={() => {
           setShow(!show);
+          // focus the editor after showing
+          cmVariables.current.editor.focus();
         }}
         style={stylesObj}
       >
         <img className={arrowClass} src={dropDownArrow} alt="" />
         Variables
       </div>
-      <div className={bodyContainerClass} style={{ marginBottom: "10px" }}>
+      <div className={bodyContainerClass} style={{ marginBottom: '10px' }}>
         <CodeMirror
+        ref={cmVariables}
           value={cmValue}
           options={{
-            mode: "graphql",
-            theme: "twilight",
-            scrollbarStyle: "native",
+            mode: 'graphql',
+            theme: 'twilight',
+            scrollbarStyle: 'native',
             lineNumbers: false,
-            lint: true,
-            hintOptions: true,
             matchBrackets: true,
             autoCloseBrackets: true,
             indentUnit: 2,
             tabSize: 2,
+            autoRefresh: true,
           }}
+          editorDidMount={editor => { editor.setSize('100%', 100) }}
           onBeforeChange={(editor, data, value) => {
-            // editor.setSize(100,100)
             setValue(value);
-            // console.log('before changing')
-            // console.log(editor);
           }}
           onChange={(editor, data, value) => {
-            // console.log('changing')
-            // console.log('onchange value', value);
             setNewRequestBody({
               ...newRequestBody,
               bodyVariables: value,
+              bodyIsNew: true,
             });
           }}
         />

--- a/src/client/components/display/History.jsx
+++ b/src/client/components/display/History.jsx
@@ -51,6 +51,7 @@ class History extends Component {
       bodyVariables: this.props.content.request.bodyVariables ? this.props.content.request.bodyVariables : '',
       rawType: this.props.content.request.rawType ? this.props.content.request.rawType : 'Text (text/plain)',
       JSONFormatted: this.props.content.request.JSONFormatted ? this.props.content.request.JSONFormatted : true,
+      bodyIsNew: false,
     }
     this.props.setNewRequestFields(requestFieldObj);
     this.props.setNewRequestHeaders(requestHeadersObj);

--- a/src/client/reducers/business.js
+++ b/src/client/reducers/business.js
@@ -42,6 +42,7 @@ const initialState = {
     bodyType: "raw",
     rawType: "Text (text/plain)",
     JSONFormatted: true,
+    bodyIsNew: false,
   },
   newRequestSSE: {
     isSSE: false,


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [X] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [X] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The codmirror variables box was not correctly updating state nor being reset when requests from history were selected
## Approach
<!--- How does your change address the problem? -->
There is a new property in state: `bodyIsNew` that is true when new input is sent to state from the function in onChange in the graphQL body and variable codemirror instances. It is false when requests from history are loaded. UseEffect in GraphQLBodyEntry and GraphQLVariable entry checks this property before resetting state. Placeholder text now correctly loads when starting a new query.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Using redux and react devtools were very helpful to watch how state was changing where as well as seeing where state was being rendered.
## Known Issues
There is a bug in the autocomplete for the GraphQL Body codemirror instance where autocompletions prevent further changes to the text until that autocompleted value is deleted.