### PR TITLE
fix autocomplete bug

### DIFF
--- a/src/client/components/composer/NewRequest/GraphQLBodyEntryForm.jsx
+++ b/src/client/components/composer/NewRequest/GraphQLBodyEntryForm.jsx
@@ -10,7 +10,6 @@ import "codemirror-graphql/hint";
 import "codemirror-graphql/lint";
 import "codemirror-graphql/mode";
 import "codemirror/addon/lint/lint.css";
-import "codemirror/addon/display/autorefresh"
 
 import dropDownArrow from "../../../../assets/icons/arrow_drop_down_white_192x192.png";
 
@@ -65,7 +64,6 @@ const GraphQLBodyEntryForm = (props) => {
             autoCloseBrackets: true,
             indentUnit: 2,
             tabSize: 2,
-            autoRefresh: true,
           }}
           editorDidMount={editor => { editor.setSize('100%', 150) }}
           onBeforeChange={(editor, data, value) => {

--- a/src/client/components/composer/NewRequest/GraphQLBodyEntryForm.jsx
+++ b/src/client/components/composer/NewRequest/GraphQLBodyEntryForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import { Controlled as CodeMirror } from "react-codemirror2";
 import "codemirror/addon/edit/matchbrackets";
 import "codemirror/addon/edit/closebrackets";
@@ -10,6 +10,7 @@ import "codemirror-graphql/hint";
 import "codemirror-graphql/lint";
 import "codemirror-graphql/mode";
 import "codemirror/addon/lint/lint.css";
+import "codemirror/addon/display/autorefresh"
 
 import dropDownArrow from "../../../../assets/icons/arrow_drop_down_white_192x192.png";
 
@@ -22,6 +23,7 @@ const GraphQLBodyEntryForm = (props) => {
     stylesObj,
     introspectionData,
   } = props;
+
   const [show, setShow] = useState(true);
   const [cmValue, setValue] = useState(bodyContent);
 
@@ -50,8 +52,6 @@ const GraphQLBodyEntryForm = (props) => {
         Body
       </div>
       <div className={bodyContainerClass} style={{ marginBottom: "10px" }}>
-        {/* conditional render to show custom keys for autocomplete */}
-        {/* {introspectionData.clientSchema ? <div>Press ___ to autocomplete</div> : '' } */}
         <CodeMirror
           value={cmValue}
           options={{
@@ -65,16 +65,13 @@ const GraphQLBodyEntryForm = (props) => {
             autoCloseBrackets: true,
             indentUnit: 2,
             tabSize: 2,
+            autoRefresh: true,
           }}
           editorDidMount={editor => { editor.setSize('100%', 150) }}
           onBeforeChange={(editor, data, value) => {
             const optionObj = {
               schema: introspectionData.clientSchema,
-              // customKeys: {
-              //   Tab: 'defaultTab', 
-              //   Enter: 'newlineAndIndent', 
-              //   Alt: 'autocomplete'
-              // }
+              completeSingle: false,
             }
             setValue(value);
             editor.setOption("lint", optionObj);


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [X] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
There was a known bug introduced in the last PR that caused accepted autocompletion hints in the GrapgQLBodyEntryForm codemirror instance to persist until the entire word was selected and deleted. Which is annoying and bad.
## Approach
<!--- How does your change address the problem? -->
By default, the option `completeSingle` in `hint/show-hint.js` is set to `true`. Setting it to `false` fixes the issue.
Autocomplete was firing because there was one option, say when the value of codemirror is "Perso" and the hint suggests "Person". State was set to "Perso" when "n" was deleted, which is correct, but then it was reset to "Person" because that was the only suggestion, which was then accepted.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Reading the [codemirror manual](https://codemirror.net/doc/manual.html) is at times challenging but ultimately that is where all the answers lie, for the commands and options anyway
`completeSingle: boolean`
    `Determines whether, when only a single completion is available, it is completed without showing the dialog. Defaults to true.`