### PR TITLE
Graphql fixes

### DIFF
--- a/main.js
+++ b/main.js
@@ -588,6 +588,7 @@ ipcMain.on("open-gql", (event, args) => {
     const body = gql`
     ${reqResObj.request.body}
     `;
+    // graphql variables: https://graphql.org/learn/queries/#variables
     const variables = reqResObj.request.bodyVariables
       ? JSON.parse(reqResObj.request.bodyVariables)
       : {};
@@ -610,8 +611,10 @@ ipcMain.on("open-gql", (event, args) => {
           console.error('gql mutation error in main.js', err);
         });
     }
-  } catch (e) {
-    console.log('error trying gql query/mutation in main.js');
+  } catch (err) {
+    console.log('error trying gql query/mutation in main.js', err);
+    reqResObj.error = JSON.stringify(err);
+    event.sender.send("reply-gql",{ error: err, reqResObj });
   }
   
 });

--- a/src/client/components/composer/NewRequest/GraphQLVariableEntryForm.jsx
+++ b/src/client/components/composer/NewRequest/GraphQLVariableEntryForm.jsx
@@ -4,14 +4,9 @@ import "codemirror/addon/edit/matchbrackets";
 import "codemirror/addon/edit/closebrackets";
 import "codemirror/theme/twilight.css";
 import "codemirror/lib/codemirror.css";
-import "codemirror/addon/hint/show-hint";
-import "codemirror/addon/hint/show-hint.css";
-import "codemirror-graphql/hint";
-import "codemirror-graphql/lint";
-import "codemirror-graphql/mode";
-import "codemirror/addon/lint/lint.css";
 import "codemirror/addon/display/autorefresh"
-
+import "codemirror/addon/display/placeholder"
+import "codemirror/mode/javascript/javascript"
 
 const GraphQLVariableEntryForm = (props) => {
   const {
@@ -31,6 +26,7 @@ const GraphQLVariableEntryForm = (props) => {
   useEffect(() => {
     if (!bodyIsNew) setValue(bodyVariables);
   }, [bodyVariables]);
+
   const bodyContainerClass = show
     ? "composer_bodyform_container-open"
     : "composer_bodyform_container-closed";
@@ -51,7 +47,7 @@ const GraphQLVariableEntryForm = (props) => {
         ref={cmVariables}
           value={cmValue}
           options={{
-            mode: 'graphql',
+            mode: { name: "javascript", json: true },
             theme: 'twilight',
             scrollbarStyle: 'native',
             lineNumbers: false,
@@ -60,6 +56,7 @@ const GraphQLVariableEntryForm = (props) => {
             indentUnit: 2,
             tabSize: 2,
             autoRefresh: true,
+            placeholder: 'Variables must be JSON format'
           }}
           editorDidMount={editor => { editor.setSize('100%', 100) }}
           onBeforeChange={(editor, data, value) => {


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [X] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [X] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
GraphQL variable entry form was incorrectly configured to format for GraphQL rather than JSON.
## Approach
<!--- How does your change address the problem? -->
GraphQL Variable entry form now properly accepts JSON text. There is however NO LINTING for JSON text, only the placeholder text specifying that the user must provide properly formatted JSON text. The reason for this is that the Codemirror editor requires another dependency: [jsonlint](https://github.com/zaach/jsonlint) and might not be necessary. It could be added later, however.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
GraphQL variables are sent [thusly](https://graphql.org/learn/queries/#variables)