### PR TITLE
Testing HTTP Controller can execute tests and correctly parse the script for user's message

### DIFF
--- a/main_process/main_httpController.js
+++ b/main_process/main_httpController.js
@@ -348,8 +348,11 @@ const httpController = {
           }
           // update reqres object to include new event
           reqResObj = this.addSingleEvent(body, reqResObj);
+          // check if there is a test script to run
+          if (reqResObj.request.testContent) {
+            reqResObj.response.testResult = testHttpController.runTest(reqResObj.request.testContent, reqResObj)
+          }
           // send back reqResObj to renderer so it can update the redux store
-          reqResObj.response.testResult = testHttpController.runTest(reqResObj.request.testContent, reqResObj)
           event.sender.send("reqResUpdate", reqResObj);
         })
         .catch((err) => {

--- a/main_process/test_controllers/main_testHttpController.js
+++ b/main_process/test_controllers/main_testHttpController.js
@@ -14,26 +14,58 @@ testHttpController.runTest = (inputScript, reqResObj) => {
   // create a new instance of a secure Node VM
   const vm = new NodeVM({
     sandbox,
-    // allow external npm modules to be required in
+    // allow only chai to be required in
     require: {
-      external: true,
+      external: ['chai'],
     },
-  })
-  // create array of individual assertion tests. 
+  });
+  // create array of individual assertion tests
+  // the regex matches all 'assert' or 'expect' only at the start of a new line
   // we remove the first element of the array because it is an empty string
-  const separatedScriptsArray = inputScript.split(/assert|expect/g).slice(1);
+  const separatedScriptsArray = inputScript.split(/^assert|^expect/gm).slice(1);
   // create an array of test scripts that will be executed in Node VM instance
-  const arrOfTestScripts = separatedScriptsArray.map(script=> (
-    `
-    if(${JSON.stringify(script[0])} === '.') {
-      const res = assert${script};
-      addOneResult(res);
-    } else if (${JSON.stringify(script[0])} === '(') {
-      const res = expect${script};
-      addOneResult(res);
+  const arrOfTestScripts = separatedScriptsArray.map(script => {
+    // Regular expression from stack overflow post below
+    // https://stackoverflow.com/a/171499
+    // this regex matches all substrings wrapped in single or double quotes
+    // and supports escaped quotes as well
+    const regEx = /(["'])(?:\\.|[^\\])*?\1/g;
+    // use the regex and return all the substrings in quotes
+    const assertionArgsInQuotes = script.match(regEx);
+    // since the user's message will always be the last argument, it will be last in the array
+    const userMessage = assertionArgsInQuotes[assertionArgsInQuotes.length - 1];
+    
+    // contstruct and return the individual test script
+    // if the assertion test does not fail, then push an object with the message and status
+    // to the results array
+    // if the assertion test fails and throws an error, also include the expected and actual
+    return `
+    try {
+      if (${JSON.stringify(script[0])} === '.') {
+        assert${script};
+        addOneResult({
+          message: ${userMessage},
+          status: 'PASS',
+        });
+      } else if (${JSON.stringify(script[0])} === '(') {
+        expect${script};
+        addOneResult({
+          message: ${userMessage},
+          status: 'PASS',
+        });
+      }
+    } catch (err) {
+      const errObj = err.toJSON();
+
+      addOneResult({
+        message: errObj.message,
+        status: 'FAIL',
+        expected: errObj.expected,
+        actual: errObj.actual,
+      });
     }
     `
-  ));
+  });
   // require in the chai assertion library
   // then concatenate all the scripts to the testScript string
   const testScript = 
@@ -47,19 +79,13 @@ testHttpController.runTest = (inputScript, reqResObj) => {
     // the second argument denotes where the vm should look for the node_modules folder
     // that is, relative to the main.js file where the electron process is running
     vm.run(testScript, 'main.js');
-    // map over the test results array and for each test result, construct an object containing
-    // the result of the test and a message 
-    const finalResults = testResults.map(result => {
-      // this property on the assertion object is the result of the assertion test i.e. pass or fail
-      if (result.__flags.object) {
-        return {result: 'Pass', message: result.__flags.message || 'Test passed'};
-      }
-      return {result: 'Fail', message: result.__flags.message || 'Test failed'};
-    });
-    return finalResults;
+    // deep clone the testResults array since sending functions, DOM elements, and non-cloneable
+    // JS objects is not supported IPC channels past Electron 9
+    return JSON.parse(JSON.stringify(testResults));
   } 
   catch (err) {
-    console.log('caught error!: in the catch block of main_testHttpController.js', err)
+    console.log('caught error!: in the catch block of main_testHttpController.js', err);
+    // return a null object in the event of an error
     return null;
   }
 };


### PR DESCRIPTION
I implemented a regex to parse for the user-supplied message.

Error objects with corresponding message property and status are added to the testResults array.

I removed console.logs.

I modified the VM instance options to only allow Chai to be required in.

Slightly modified existing regex to be more robust and handle edge cases where 'assert' or 'expect' could be somewhere else in the string. The code only looks for 'assert' or 'expect' at the beginning of a new line.

Added conditional in the main Http controller to only invoke the test controller if there is a test script. This may break how the test tab is working since that piece of state will be missing if no tests are run. The test tab should be refactored to conditionally render depending on if there are actually any test results.