### PR TITLE
Fix UI and chrome dev tool to show only in dev mode

### DIFF
--- a/menu/mainMenu.js
+++ b/menu/mainMenu.js
@@ -52,6 +52,7 @@ const template = [
       //THIS ENABLES DEVELOPER TOOLS IN THE BUILT APPLICATION
       {
         label: "Toggle Developer Tools",
+        visible: process.env.NODE_ENV === "development",
         accelerator:
           process.platform === "darwin" ? "Alt+Command+I" : "Ctrl+Shift+I", // another keyboard shortcut that will be conditionally assigned depending on whether or not user is on macOS
         click(item, focusedWindow) {

--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
       "main_process/main_wsController.js",
       "main_process/main_touchbar.js",
       "main_process/SSEController.js",
+      "main_process/test_controllers/main_testHttpController.js",
       "preload.js"
     ],
     "nodeVersion": "12.14.1",

--- a/src/client/components/composer/NetworkDropdown.jsx
+++ b/src/client/components/composer/NetworkDropdown.jsx
@@ -41,8 +41,8 @@ export default function NetworkDropdown({ onProtocolSelect, network }) {
         </div>
       </div>
 
-      <div className="dropdown-menu">
-        <div className="dropdown-content">
+      <div className="dropdown-menu full-width is-fullwidth">
+        <div className="dropdown-content full-width is-fullwidth has-text-centered">
           <a  
             onClick={() => {
               setDropdownIsActive(false);


### PR DESCRIPTION
Adjust ui for network protocol dropdown menu and chrome dev tool to be only visible in development mode