### PR TITLE
Changed port number for gRPC tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -46,7 +46,7 @@ const { introspectionQuery } = require("graphql");
 
 // proto-parser func for parsing .proto files
 const protoParserFunc = require("./main_process/protoParser.js");
-//TESTING
+// testing controller for HTTP requests
 const testHttpController = require("./main_process/test_controllers/main_testHttpController");
 
 // require menu file

--- a/test/grpcServer.js
+++ b/test/grpcServer.js
@@ -4,7 +4,7 @@ const protoLoader = require("@grpc/proto-loader");
 
 // change PROTO_PATH to load a different mock proto file
 const PROTO_PATH = path.resolve(__dirname, "./hw2.proto");
-const PORT = "0.0.0.0:50051";
+const PORT = "0.0.0.0:30051";
 
 // Service method to be used on unary test
 const SayHello = (call, callback) => {
@@ -93,4 +93,4 @@ function main(status) {
   } 
 }
 
-module.exports = main
+module.exports = main;

--- a/test/subSuites/grpcTest.js
+++ b/test/subSuites/grpcTest.js
@@ -38,7 +38,7 @@ module.exports = () => {
       try {
         await grpcObj.selectedNetwork.click();
         await grpcObj.gRPCNetwork.click();
-        await grpcObj.url.addValue("0.0.0.0:50051");
+        await grpcObj.url.addValue("0.0.0.0:30051");
         await grpcObj.grpcProto.addValue(proto);
         await grpcObj.saveChanges.click();
       } catch(err) {


### PR DESCRIPTION
I changed  the port number for the gRPC tests  to 30051. It looks like something on Windows uses that port so the app can't bind to it. This should be fine on Mac, Windows, Linux.