### PR TITLE
Modifications to webrtcPeerController.ts, WebRTCComposer.tsx, WebRTCServerEntryForm.tsx, WebRTCSessionEntryForm.tsx

### DIFF
--- a/src/client/components/main/WebRTC-composer/WebRTCComposer.tsx
+++ b/src/client/components/main/WebRTC-composer/WebRTCComposer.tsx
@@ -35,6 +35,7 @@ export default function WebRTCComposer(props: $TSFixMe) {
     },
     newTestContentSet,
     newRequestBodySet,
+
     newRequestBody,
     newRequestBody: { rawType, bodyContent, bodyVariables, bodyType },
     newRequestHeadersSet,
@@ -60,6 +61,7 @@ export default function WebRTCComposer(props: $TSFixMe) {
       graphQL,
       gRPC,
       webrtc: true,
+
       url,
       timeSent: null,
       timeReceived: null,
@@ -69,7 +71,6 @@ export default function WebRTCComposer(props: $TSFixMe) {
       webrtcData,
       request: {
         method,
-        webrtcData,
         url,
         messages: [],
         body: bodyContent || '',
@@ -89,12 +90,10 @@ export default function WebRTCComposer(props: $TSFixMe) {
       tab: currentTab,
     };
 
-    // add request to history
     /** @todo Fix this TS type error  */
     historyController.addHistoryToIndexedDb(reqRes);
     reqResItemAdded(reqRes);
 
-    //reset for next request
     composerFieldsReset();
 
     newRequestBodySet({

--- a/src/client/components/main/WebRTC-composer/WebRTCServerEntryForm.tsx
+++ b/src/client/components/main/WebRTC-composer/WebRTCServerEntryForm.tsx
@@ -56,7 +56,7 @@ const WebRTCServerEntryForm: React.FC<Props> = ({ warningMessage }) => {
           theme={vscodeDark}
           extensions={[javascript(), EditorView.lineWrapping]}
           height="100px"
-          readOnly={true}
+          readOnly={false}
         />
       </div>
     </div>

--- a/src/client/components/main/WebRTC-composer/WebRTCServerEntryForm.tsx
+++ b/src/client/components/main/WebRTC-composer/WebRTCServerEntryForm.tsx
@@ -70,6 +70,7 @@ export default WebRTCServerEntryForm;
 //   const requestBody = useSelector((state) => state.newRequest.newRequestBody);
 //   const { bodyIsNew } = requestBody;
 //   const [cmValue, setValue] = useState('');
+
 //   const isDark = useSelector((state) => state.ui.isDark);
 
 //   const bodyContent = useSelector(

--- a/src/client/components/main/WebRTC-composer/WebRTCSessionEntryForm.tsx
+++ b/src/client/components/main/WebRTC-composer/WebRTCSessionEntryForm.tsx
@@ -19,7 +19,7 @@ const WebRTCSessionEntryForm: React.FC<Props> = ({ warningMessage }) => {
         placeholder="No url needed"
         // disabled
       />
-      {warningMessage.uri && 
+      {warningMessage.uri && (
         <div className="warningMessage">{warningMessage.uri}</div>
       )}
     </div>

--- a/src/client/components/main/WebRTC-composer/WebRTCSessionEntryForm.tsx
+++ b/src/client/components/main/WebRTC-composer/WebRTCSessionEntryForm.tsx
@@ -6,7 +6,10 @@ interface Props {
 
 const WebRTCSessionEntryForm: React.FC<Props> = ({ warningMessage }) => {
   return (
-    <div className="is-flex is-justify-content-center" style={{ padding: '10px' }}>
+    <div
+      className="is-flex is-justify-content-center"
+      style={{ padding: '10px' }}
+    >
       <div id="webRTButton" className="no-border-please button is-webrtc">
         <span>SDP</span>
       </div>
@@ -14,16 +17,16 @@ const WebRTCSessionEntryForm: React.FC<Props> = ({ warningMessage }) => {
         className="ml-1 input input-is-medium is-info"
         type="text"
         placeholder="No url needed"
-        disabled
+        // disabled
       />
-      {warningMessage.uri && <div className="warningMessage">{warningMessage.uri}</div>}
+      {warningMessage.uri && 
+        <div className="warningMessage">{warningMessage.uri}</div>
+      )}
     </div>
   );
 };
 
 export default WebRTCSessionEntryForm;
-
-
 
 // import React from 'react';
 

--- a/src/client/controllers/webrtcPeerController.ts
+++ b/src/client/controllers/webrtcPeerController.ts
@@ -25,10 +25,9 @@ class Peer {
     const configuration: RTCConfiguration = {
       iceServers,
     };
-
+    //returning a new RTCPeer connection object with the appropriate configuration
     return new RTCPeerConnection(configuration);
   }
-
   async establishSDP() {
     this.connection.createDataChannel('test');
     this.connection
@@ -37,7 +36,6 @@ class Peer {
         this.connection.setLocalDescription(offer)
       );
   }
-
   async establishAnswer(offer: RTCSessionDescriptionInit) {
     const remoteOffer = new RTCSessionDescription(offer);
     await this.connection.setRemoteDescription(remoteOffer);

--- a/src/client/controllers/webrtcPeerController.ts
+++ b/src/client/controllers/webrtcPeerController.ts
@@ -1,5 +1,5 @@
 import {
-  reqResUpdated,
+  reqResUpdated, //understand how these are being used and what is happening to state as it is passed into
   responseDataSaved,
 } from '../toolkit-refactor/slices/reqResSlice';
 import { appDispatch } from '../toolkit-refactor/store';
@@ -9,16 +9,24 @@ class Peer {
   config: RTCConfiguration;
   connection: RTCPeerConnection;
 
-  constructor(config: RTCConfiguration) {
+  constructor(config: RTCConfiguration, iceServerUrl: string[]) {
     this.config = config;
-    this.connection = this.createConnection();
+    this.connection = this.createConnection(iceServerUrl);
     this.connection.onicecandidateerror = (e: Event) => {
       console.error(e);
     };
   }
 
-  createConnection(): RTCPeerConnection {
-    return new RTCPeerConnection(this.config);
+  createConnection(iceServerUrl: string[]): RTCPeerConnection {
+    // createConnection accepts a iceServerUrl with a type of an array of strings, the function is of type RTCPeerConnection (necessary object)
+    const iceServers: RTCIceServer[] = iceServerUrl.map((url) => ({
+      urls: url,
+    })); //const iceServers has a type of RTCIceServer[] mapping every url in the array to the RTCIceServer urls property
+    const configuration: RTCConfiguration = {
+      iceServers,
+    };
+
+    return new RTCPeerConnection(configuration);
   }
 
   async establishSDP() {
@@ -29,12 +37,26 @@ class Peer {
         this.connection.setLocalDescription(offer)
       );
   }
-}
 
+  async establishAnswer(offer: RTCSessionDescriptionInit) {
+    const remoteOffer = new RTCSessionDescription(offer);
+    await this.connection.setRemoteDescription(remoteOffer);
+
+    const answer = await this.connection.createAnswer();
+    await this.connection.setLocalDescription(answer);
+  }
+}
+//replaced with a function that responds with the SDP answer after clicking send
+//content should already contain offer/answer string
+//inside the function use those strings to create connection
+//Answer SDP should be contained in ReqRes obj
 // `ReqRes` type need to be fixed consistently across the board
 // To make the type for `content` work properly
+
+//Ideally creating the answer here not sure what testSDP connection is testing if there is no generated answer already
+
 export default async function testSDPConnection(content) {
-  const { iceConfiguration } = content.request.body;
+  const { iceConfiguration, offer } = content.request.body;
   // Technically, setting the connection status as 'closed' right away
   // is not entirely accurated. Since we are closing the server a second
   // after it is opened to avoid timeout issue anyway, this is as good
@@ -42,8 +64,12 @@ export default async function testSDPConnection(content) {
   // Also, the current setup only works with one iceServer. To expand
   // this feature we need to get the relevant `ReqRes` from `Store.getState()`
   // and add the response there. See `graphQLController.openSubscription()` for example
+  const iceServerUrl: string[] = [
+    'stun:stun1.1.google.com:19302',
+    'stun:stun2.1.google.com:19302',
+  ];
   const newReqRes = { ...content, connection: 'closed' };
-  const pc = new Peer(iceConfiguration);
+  const pc = new Peer(iceConfiguration, iceServerUrl);
   pc.connection.onicecandidate = (e) => {
     if (!e.candidate) return;
 
@@ -83,10 +109,10 @@ export default async function testSDPConnection(content) {
       console.log('TURN Server is reachable!');
     }
   };
-  pc.establishSDP();
-  setTimeout(() => {
-    pc.connection.close();
-    console.log('WebRTC connection closed.');
-  }, 1000);
+  await pc.establishAnswer(offer); //Generate/set the answer based on the provided offer
+  const answer = pc.connection.localDescription; //get the generated answer
+
+  pc.connection.close(); //close the connection
+  return answer; //Return the SDP answer => send to the UI to be displayed
 }
 


### PR DESCRIPTION
1. Added iceServerUrl parameter to Peer constructor
![Added iceServerUrl to Peer constructor](https://github.com/oslabs-beta/Swell/assets/98367967/2f4100fe-f853-4a24-a065-92e4a691d077)

2. Modified createConnection() method to accept the iceServerUrl and returning a new instance of RTCPeerConnection with the appropriate configuration. 
![Passing in Ice Server to create connection](https://github.com/oslabs-beta/Swell/assets/98367967/4d7ed025-6b88-4efc-bfcc-bca42aab378e)

3. Modified testSDPConnection() by adding the offer in the request body and explicitly defining the iceServerUrl
![explicitly defining iceServerUrl](https://github.com/oslabs-beta/Swell/assets/98367967/5e2e2c7c-fbd5-4688-a0bb-cf2de7e885a0)

4. Generated, set, and returned answer SDP
![Awaiting the Answer and returning SDP answer](https://github.com/oslabs-beta/Swell/assets/98367967/7e6d9581-7b82-422f-8052-6a633b15dfd9)

5. Modified STUN/TURN server info  readOnly flag to false. Intended to pivot towards providing input area for SDP offer
![WebRTCServerEntryForm tsx](https://github.com/oslabs-beta/Swell/assets/98367967/df957d06-25ab-4f44-9d60-05701cd84ed7)
6. Enabled Text Field at WebRTCSessionEntryForm.tsx 
![WebRTCSessionEntryForm tsx](https://github.com/oslabs-beta/Swell/assets/98367967/c11ab5cf-3671-42f6-92b7-994a8171062e)



