### PR TITLE
Fixed gRPC bug that did not allow user to modify body of protocol buffer

### DIFF
--- a/src/client/components/main/GRPC-composer/GRPCBodyEntryForm.tsx
+++ b/src/client/components/main/GRPC-composer/GRPCBodyEntryForm.tsx
@@ -41,10 +41,9 @@ const GRPCBodyEntryForm: React.FC<Props> = (props) => {
     // props.saveChanges(false);
     const streamsArr = [...props.newRequestStreams.streamsArr];
     const streamContent = [...props.newRequestStreams.streamContent];
-
     for (let i = 0; i < streamsArr.length; i++) {
       if (streamsArr[i].id === streamID) {
-        streamsArr[streamID].query = value;
+        streamsArr[streamID] = { ...streamsArr[streamID], query: value };
         streamContent[streamID] = value;
         props.newRequestStreamsSet({
           ...props.newRequestStreams,

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,8 +200,7 @@ export type NewRequestFields = {
   openapiReqObj: Record<string, $TSFixMe>;
 };
 
-//& DOnt think this is really being used anymore?
-//& ACTUALLY look below at ReqRes and seems to be assigned to key 'request'
+
 export interface ReqResRequest {
   // Currently, the body for WebRTC connection is an object
   // and typescript does not support union between string and object very well

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,8 @@ export type NewRequestFields = {
   openapiReqObj: Record<string, $TSFixMe>;
 };
 
+//& DOnt think this is really being used anymore?
+//& ACTUALLY look below at ReqRes and seems to be assigned to key 'request'
 export interface ReqResRequest {
   // Currently, the body for WebRTC connection is an object
   // and typescript does not support union between string and object very well

--- a/test/grpcServer.js
+++ b/test/grpcServer.js
@@ -10,6 +10,7 @@ const PORT = '0.0.0.0:30051';
 
 // Service method to be used on unary test
 const SayHello = (call, callback) => {
+  console.log(call);
   callback(null, { message: `Hello ${call.request.name}` });
 };
 // client.users.byId.query("1");

--- a/test/grpcServer.js
+++ b/test/grpcServer.js
@@ -10,7 +10,6 @@ const PORT = '0.0.0.0:30051';
 
 // Service method to be used on unary test
 const SayHello = (call, callback) => {
-  console.log(call);
   callback(null, { message: `Hello ${call.request.name}` });
 };
 // client.users.byId.query("1");


### PR DESCRIPTION
Any time a user would try to modify the body of the request, this error would appear

![image](https://github.com/oslabs-beta/Swell/assets/100450515/89f8c0ec-a16b-4775-97b5-c090801b8e8e)
