### PR TITLE
Completed gRPC integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/open-source-labs/Swell",
   "scripts": {
     "report": "istanbul report --dir ./test/coverage/total-coverage html",
-    "test": "webpack --mode=production --config ./webpack.production.js && cross-env process.env.NODE_ENV=test nyc --report-dir ./test/coverage/mocha-coverage --reporter json --reporter text --reporter html mocha --exit",
+    "test": "webpack --mode=production --config ./webpack.production.js && cross-env process.env.NODE_ENV=test nyc --report-dir ./test/coverage/mocha-coverage --reporter json --reporter text --reporter html mocha --timeout 3000 --exit",
     "server-sse": "node ./test/SSE_HTTP1_server.js",
     "server-gql": "node ./test/graphqlServer.mjs",
     "server-grpc": "node ./test/grpcServer.js",
@@ -16,7 +16,8 @@
     "server-websocket": "node ./test/websocketServer.js",
     "server-webrtc": "node ./test/webrtcWSServer.js",
     "test-jest": "jest",
-    "test-mocha": "webpack --mode=production --config ./webpack.production.js && cross-env process.env.NODE_ENV=test mocha --exit",
+    "test-mocha": "webpack --mode=production --config ./webpack.production.js && cross-env process.env.NODE_ENV=test mocha --timeout 3000 --exit",
+    "test-mocha-zero": "webpack --mode=production --config ./webpack.production.js && cross-env process.env.NODE_ENV=test mocha --timeout 0 --exit",
     "format": "prettier --write \"**/*.+(js|jsx| tsx| json|css|md)\"",
     "lint": "eslint .",
     "lint:fix": "eslint --fix . ",

--- a/test/IntegrationTests/grpcIntegrationTests.js
+++ b/test/IntegrationTests/grpcIntegrationTests.js
@@ -24,9 +24,10 @@ const projectPath = path.resolve(__dirname, '..', '..', 'main.js');
 
 module.exports = () => {
   describe('gRPC Integration Testing', () => {
+    
     before(async () => {
       electronApp = await electron.launch({ args: [projectPath] });
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await new Promise(resolve => setTimeout(resolve, 500));
       page = await electronApp.windows()[0]; // In case there is more than one window
       await page.waitForLoadState(`domcontentloaded`);
       grpcServer('open');
@@ -34,16 +35,14 @@ module.exports = () => {
     });
 
     //& Make a before each that resets the workspace and all
-    // beforeEach(async () => {
-    //   await page.locator('button>> text=GRPC').click();
-    //   await page.locator('#url-input').fill('0.0.0.0:30051');
-    //   // Auto fill proto
-
-    // });
+    beforeEach(async () => {
+      await page.locator('button >> text=Clear Workspace').click();
+    });
 
     after(async () => {
       if (page) await page.locator('button >> text=Clear Workspace').click();
       await electronApp.close();
+      grpcServer('close');
     });
 
     it('State is being properly handled in an Unary RPC', async () => {
@@ -93,19 +92,101 @@ module.exports = () => {
       const response = { "message": "Hello Nate"};
       await page.locator(`#send-button-${num}`).click();
       await page.waitForLoadState();
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await new Promise(resolve => setTimeout(resolve, 100));
       reduxState = await page.evaluate(() => window.getReduxState());
       expect(reduxState.reqRes.currentResponse.gRPC).to.equal(true);
       expect(reduxState.reqRes.reqResArray[0].response.events[0]).to.deep.equal(response);
       expect(reduxState.reqRes.currentResponse.response.events[0]).to.deep.equal(response);
     });
 
-    it('State is being handled ', () => {
-      console.log('first test')
+    it('State is being properly handled in a Server Stream RPC', async () => {
+      let reduxState;
+      // Add Proto
+      let codeMirror = await page.locator('#grpcProtoEntryTextArea');
+      await codeMirror.click();
+      let gRPC_BodyCode = await codeMirror.locator('.cm-content');
+      await gRPC_BodyCode.fill(`${proto}`);
+      await page.locator('#save-proto').click();
+      // Setting 'Greeter'
+      await page.locator('#Select-Service-button').click();
+      await page.locator('.dropdown-menu >> a >> text=Greeter').click();
+      // Setting the 'SayHellosSs' Option
+      await page.locator('#Select-Request-button').click();
+      await page.getByText('SayHellosSs', { exact: true }).click();
+      reduxState = await page.evaluate(() => window.getReduxState());
+      expect(reduxState.newRequest.newRequestStreams.selectedRequest).to.equal('SayHellosSs')
+      // Set the body
+      const grpcBody = '{"name":"Nate"}'
+      codeMirror = await page.locator('#grpcBodyEntryTextArea');
+      await codeMirror.click();
+      gRPC_BodyCode = await codeMirror.locator('.cm-content');
+      await gRPC_BodyCode.fill(`${grpcBody}`);
+      // Add to workspace
+      await page.locator('button >> text=Add to Workspace').click();
+      // Send response
+      await page.locator(`#send-button-${num}`).click();
+      await page.waitForLoadState();
+      await new Promise(resolve => setTimeout(resolve, 500));
+      // Check state of resposne
+      reduxState = await page.evaluate(() => window.getReduxState());
+      expect(reduxState.reqRes.reqResArray[0].response.events.length).to.equal(5);
+      expect(reduxState.reqRes.reqResArray[0].response.events[2]).to.deep.equal({"message":"doing IT"});
+      expect(reduxState.reqRes.reqResArray[0].response.events[4]).to.deep.equal({"message":"hello!!! Nate"});
     });
 
-    it('test 123', () => {
-      console.log('first test')
+    it('State is being properly handled in a Client Stream RPC', async () => {
+      let reduxState;
+      // Add Proto
+      let codeMirror = await page.locator('#grpcProtoEntryTextArea');
+      await codeMirror.click();
+      let gRPC_BodyCode = await codeMirror.locator('.cm-content');
+      await gRPC_BodyCode.fill(`${proto}`);
+      await page.locator('#save-proto').click();
+      // Setting 'Greeter'
+      await page.locator('#Select-Service-button').click();
+      await page.locator('.dropdown-menu >> a >> text=Greeter').click();
+      // Setting the 'SayHelloCS' Option
+      await page.locator('#Select-Request-button').click();
+      await page.getByText('SayHelloCS', { exact: true }).click();
+      reduxState = await page.evaluate(() => window.getReduxState());
+      expect(reduxState.newRequest.newRequestStreams.selectedRequest).to.equal('SayHelloCS')
+      await page.getByText('Add Stream').click();
+      await page.getByText('Add Stream').click();
+
+      // Set text for each of streams
+      const inputBoxes = await page.locator('#grpcBodyEntryTextArea').all()
+      for(let i = 0; i< inputBoxes.length; i++){
+        const currBox = inputBoxes[i];
+        await currBox.click()
+        let inputText = await currBox.locator('.cm-content');
+        await inputText.fill(`{"name":"Stream${i}"}`);
+        // await new Promise(resolve => {});
+
+      }
+      // Check if state is properly updated with all these streams
+      reduxState = await page.evaluate(() => window.getReduxState());
+      expect(reduxState.newRequest.newRequestStreams.count).to.equal(3);
+      for(let i = 0; i< inputBoxes.length; i++){
+        const inputedStream = JSON.parse(reduxState.newRequest.newRequestStreams.streamContent[i]);
+        expect(inputedStream.name).to.equal(`Stream${i}`)
+      }
+      // Add to workspace
+      await page.locator('button >> text=Add to Workspace').click();
+      // Send response
+      await page.locator(`#send-button-${num}`).click();
+      await page.waitForLoadState();
+      await new Promise(resolve => setTimeout(resolve, 500));
+      // Check state of response
+      reduxState = await page.evaluate(() => window.getReduxState());
+      expect(reduxState.reqRes.reqResArray[0].streamContent.length).to.equal(3)
+      const response = JSON.parse(reduxState.reqRes.reqResArray[0].streamContent[1])
+      expect(response.name).to.deep.equal("Stream1")
+
+      
+      // this.timeout(0);
+      // console.log('made it to the end')
+      // await new Promise(resolve => {});
+
     });
   }).timeout(20000);
 };

--- a/test/IntegrationTests/httpIntegrationTests.js
+++ b/test/IntegrationTests/httpIntegrationTests.js
@@ -45,7 +45,6 @@ module.exports = () => {
       });
       const response = await fetch('http://localhost:3004/book')
       const data = await response.json()
-      console.log(data)
 
     });
 

--- a/test/grpcServer.js
+++ b/test/grpcServer.js
@@ -6,7 +6,7 @@ const protoLoader = require('@grpc/proto-loader');
 
 const PROTO_PATH = path.resolve(__dirname, './hw2.proto');
 const PORT = '0.0.0.0:30051';
-
+let server;
 
 // Service method to be used on unary test
 const SayHello = (call, callback) => {
@@ -104,7 +104,7 @@ function main(status) {
   const pkg = grpc.loadPackageDefinition(proto);
   if (status === 'open') {
     // create new instance of grpc server
-    const server = new grpc.Server();
+    server = new grpc.Server();
 
     // add service and methods to the server
     server.addService(pkg.helloworld.Greeter.service, {
@@ -121,6 +121,12 @@ function main(status) {
       console.log(`gRPC Test Server: listening on PORT ${PORT}`);
     });
   }
+  else if (status === 'close' && server) {
+    server.tryShutdown(() => {
+      console.log('gRPC Test Server has been shut down.');
+    });
+  }
+
 }
 
 // uncomment this line of code if you want to run the server

--- a/test/subSuites/grpcTest.js
+++ b/test/subSuites/grpcTest.js
@@ -34,6 +34,7 @@ module.exports = () => {
     // close Electron app when complete
     after(async () => {
       await electronApp.close();
+      grpcServer('close');
     });
 
     afterEach(async function () {

--- a/test/subSuites/grpcTestingTest.js
+++ b/test/subSuites/grpcTestingTest.js
@@ -33,12 +33,15 @@ module.exports = () => {
       if (!electronApp) {
         throw new Error('electronApp failed t launch');
       }
+      grpcServer('open');
+
     });
 
     // close Electron app when complete
     after(async () => {
       await page.locator('button >> text=Clear Workspace').click();
       await electronApp.close();
+      grpcServer('close');
     });
 
     afterEach(async function () {

--- a/test/testSuite.js
+++ b/test/testSuite.js
@@ -49,29 +49,29 @@ const fs = require('fs-extra');
 // Remove all files from "failedTests" directory on launching the tests, we want only the most recent test screenshots
 fs.emptyDirSync(path.resolve(__dirname + '/failedTests'));
 
-// // Testing suite
-// describe('Electron UI Rendering', function () { // group of tests that focuses on how app renders its UI + handles screenshots for failed tests
-//   appOpensTests();
-// }).timeout(20000);
+// Testing suite
+describe('Electron UI Rendering', function () { // group of tests that focuses on how app renders its UI + handles screenshots for failed tests
+  appOpensTests();
+}).timeout(20000);
 
-// describe('Protocol selection and usage', function () { //group of tests that focuses on how application handles different protocols
-//   reqInputTests();
-//   httpTest();
-//   graphqlTest();
-//   websocketTest();
-//   grpcTest();
-//   webRTCTest();
-//   openAPITest();
-// }).timeout(20000);
+describe('Protocol selection and usage', function () { //group of tests that focuses on how application handles different protocols
+  reqInputTests();
+  httpTest();
+  graphqlTest();
+  websocketTest();
+  grpcTest();
+  webRTCTest();
+  openAPITest();
+}).timeout(20000);
 
-// describe('Request/response testing functionality', function () {
-//   httpTestingTest();
-//   grpcTestingTest();
-//   graphqlTestingTest();
-// }).timeout(20000);
+describe('Request/response testing functionality', function () {
+  httpTestingTest();
+  grpcTestingTest();
+  graphqlTestingTest();
+}).timeout(20000);
 
 describe('Integration testing', function() {
-  // httpIntegrationTests()
-  // grpcIntegrationTests()
-  graphQLIntegrationTests();
+  httpIntegrationTests()
+  grpcIntegrationTests()
+  // graphQLIntegrationTests();
 }).timeout(20000)

--- a/test/testSuite.js
+++ b/test/testSuite.js
@@ -71,7 +71,7 @@ describe('Request/response testing functionality', function () {
 }).timeout(20000);
 
 describe('Integration testing', function() {
-  httpIntegrationTests()
-  grpcIntegrationTests()
-  // graphQLIntegrationTests();
+  httpIntegrationTests();
+  grpcIntegrationTests();
+  graphQLIntegrationTests();
 }).timeout(20000)


### PR DESCRIPTION
- Added integration tests for Server and Client stream requests
- modified test script to run with a timeout of 3 seconds (instead of 2 seconds). One of the gRPC integration tests was taking over 2 seconds and it would auto-fail
- added a new script 'test-mocha-zero' to allow for running tests in a no timeout environment
- modified gRPC server to have a close function. previous gRPC tests were not closing the gRPC server after test completion.